### PR TITLE
fix the heading style was not reflected

### DIFF
--- a/tutorials/frontend/angular-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
+++ b/tutorials/frontend/angular-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
@@ -5,7 +5,9 @@ metaDescription: "Try out GraphQL Query using GraphiQL. A GraphQL query example 
 ---
 
 <a name="graphiql"></a>
+
 ## Try out GraphQL queries
+
 For this tutorial we've set up a GraphQL API for you. The most common
 way to browse a GraphQL API is to use GraphiQL. GraphiQL is a tool
 built by Facebook, (pronounced "graphical") that makes it easy to explore
@@ -150,6 +152,7 @@ Notice that we are passing arguments to different fields. This GraphQL query rea
 <b><a href="https://learn.hasura.io/graphql/graphiql" target="_blank">Try it out in GraphiQL</a></b>
 
 <a name="query-variables"></a>
+
 ## GraphQL variables: Passing arguments to your queries dynamically
 
 This is great, but we still have a problem. If we want to create a query

--- a/tutorials/frontend/elm-graphql/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
+++ b/tutorials/frontend/elm-graphql/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
@@ -5,6 +5,7 @@ metaDescription: "Try out GraphQL Query using GraphiQL. A GraphQL query example 
 ---
 
 <a name="graphiql"></a>
+
 ## Try out GraphQL queries
 
 For this tutorial we've set up a GraphQL API for you. The most common
@@ -153,6 +154,7 @@ Notice that we are passing arguments to different fields. This GraphQL query rea
 <b><a href="https://learn.hasura.io/graphql/graphiql?tutorial=react-native" target="_blank">Try it out in GraphiQL</a></b>
 
 <a name="query-variables"></a>
+
 ## GraphQL variables: Passing arguments to your queries dynamically
 
 This is great, but we still have a problem. If we want to create a query

--- a/tutorials/frontend/react-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
+++ b/tutorials/frontend/react-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
@@ -156,6 +156,7 @@ Notice that we are passing arguments to different fields. This GraphQL query rea
 <b><a href="https://learn.hasura.io/graphql/graphiql" target="_blank">Try it out in GraphiQL</a></b>
 
 <a name="query-variables"></a>
+
 ## GraphQL variables: Passing arguments to your queries dynamically
 
 This is great, but we still have a problem. If we want to create a query

--- a/tutorials/frontend/typescript-react-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
+++ b/tutorials/frontend/typescript-react-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
@@ -152,6 +152,7 @@ Notice that we are passing arguments to different fields. This GraphQL query rea
 <b><a href="https://learn.hasura.io/graphql/graphiql" target="_blank">Try it out in GraphiQL</a></b>
 
 <a name="query-variables"></a>
+
 ## GraphQL variables: Passing arguments to your queries dynamically
 
 This is great, but we still have a problem. If we want to create a query

--- a/tutorials/frontend/vue-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
+++ b/tutorials/frontend/vue-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
@@ -9,7 +9,9 @@ import YoutubeEmbed from "../../src/YoutubeEmbed.js";
 <YoutubeEmbed link="https://www.youtube.com/embed/ygUDIeiYZNA" />
 
 <a name="graphiql"></a>
+
 ## Try out GraphQL queries
+
 For this tutorial we've set up a GraphQL API for you. The most common
 way to browse a GraphQL API is to use GraphiQL. GraphiQL is a tool
 built by Facebook, (pronounced "graphical") that makes it easy to explore
@@ -154,6 +156,7 @@ Notice that we are passing arguments to different fields. This GraphQL query rea
 <b><a href="https://learn.hasura.io/graphql/graphiql" target="_blank">Try it out in GraphiQL</a></b>
 
 <a name="query-variables"></a>
+
 ## GraphQL variables: Passing arguments to your queries dynamically
 
 This is great, but we still have a problem. If we want to create a query

--- a/tutorials/mobile/flutter-graphql/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
+++ b/tutorials/mobile/flutter-graphql/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
@@ -5,7 +5,9 @@ metaDescription: "Try out GraphQL Query using GraphiQL. A GraphQL query example 
 ---
 
 <a name="graphiql"></a>
+
 ## Try out GraphQL queries
+
 For this tutorial we've set up a GraphQL API for you. The most common
 way to browse a GraphQL API is to use GraphiQL. GraphiQL is a tool
 built by Facebook, (pronounced "graphical") that makes it easy to explore
@@ -150,6 +152,7 @@ Notice that we are passing arguments to different fields. This GraphQL query rea
 <b><a href="https://learn.hasura.io/graphql/graphiql?tutorial=react-native" target="_blank">Try it out in GraphiQL</a></b>
 
 <a name="query-variables"></a>
+
 ## GraphQL variables: Passing arguments to your queries dynamically
 
 This is great, but we still have a problem. If we want to create a query

--- a/tutorials/mobile/react-native-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
+++ b/tutorials/mobile/react-native-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
@@ -9,7 +9,9 @@ import YoutubeEmbed from "../../src/YoutubeEmbed.js";
 <YoutubeEmbed link="https://www.youtube.com/embed/xyI6w3vL_vw"/>
 
 <a name="graphiql"></a>
+
 ## Try out GraphQL queries
+
 For this tutorial we've set up a GraphQL API for you. The most common
 way to browse a GraphQL API is to use GraphiQL. GraphiQL is a tool
 built by Facebook, (pronounced "graphical") that makes it easy to explore
@@ -154,6 +156,7 @@ Notice that we are passing arguments to different fields. This GraphQL query rea
 <b><a href="https://learn.hasura.io/graphql/graphiql?tutorial=react-native" target="_blank">Try it out in GraphiQL</a></b>
 
 <a name="query-variables"></a>
+
 ## GraphQL variables: Passing arguments to your queries dynamically
 
 This is great, but we still have a problem. If we want to create a query


### PR DESCRIPTION
## Description
The "intro-to-graphql/2-fetching-data-queries" page heading style was not reflected.
ex) https://learn.hasura.io/graphql/flutter-graphql/intro-to-graphql/2-fetching-data-queries
## Fixes
before
![スクリーンショット 2019-10-04 3 02 41](https://user-images.githubusercontent.com/26357644/66152016-78827380-e653-11e9-9afa-c3440f93930a.png)

after
![スクリーンショット 2019-10-04 3 02 04](https://user-images.githubusercontent.com/26357644/66152222-03fc0480-e654-11e9-9e6e-3bddf8b098db.png)

