### PR TITLE
fixes broken link to website in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [learn.hasura.io](learn.hasura.io)
+# [learn.hasura.io](https://learn.hasura.io)
 
 Real world GraphQL tutorials for frontend developers with deadlines!
 With these tutorials, you will move from the basics of GraphQL to building a real-time application in 2 hours


### PR DESCRIPTION
The README.md links to https://github.com/hasura/learn-graphql/blob/master/learn.hasura.io, which is a 404 page for GitHub. This appends https:// to the link so it opens into the correct page, https://learn.hasura.io/.