### PR TITLE
Fix broken links

### DIFF
--- a/tutorials/frontend/react-apollo/tutorial-site/content/mutations-variables/3-create-mutation.md
+++ b/tutorials/frontend/react-apollo/tutorial-site/content/mutations-variables/3-create-mutation.md
@@ -41,7 +41,7 @@ const TodoInput = ({isPublic=false}) => {
 };
 ```
 
-In the `<Mutation>` component defined above, the first argument of the render prop function is the mutate function; (addTodo) in this case. Read more about the mutate function [here](https://www.apollographql.com/docs/react/essentials/mutations.html#render-prop)
+In the `<Mutation>` component defined above, the first argument of the render prop function is the mutate function; (addTodo) in this case. Read more about the mutate function [here](https://www.apollographql.com/docs/react/data/mutations/)
 
 The mutate function optionally takes variables, optimisticResponse, refetchQueries, and update; You are going to make use of the `update` function later.
 

--- a/tutorials/frontend/react-apollo/tutorial-site/content/queries/2-create-query.md
+++ b/tutorials/frontend/react-apollo/tutorial-site/content/queries/2-create-query.md
@@ -198,7 +198,7 @@ When you wrapped your return with `<Query>` component, Apollo injected props int
 
 `data`: An object containing the result of your GraphQL query. This will contain our actual data from the server. In our case, it will be the todo data.
 
-You can read more about other render props that Apollo passes [here](https://www.apollographql.com/docs/react/essentials/queries.html#render-prop)
+You can read more about other render props that Apollo passes [here](https://www.apollographql.com/docs/react/data/queries/)
 
 Using the `data` prop, we are parsing the results from the server. In our query, `data` prop has an array `todos` which can be mapped over to render each `TodoItem`.
 

--- a/tutorials/frontend/typescript-react-apollo/tutorial-site/content/mutations-variables/3-create-mutation.md
+++ b/tutorials/frontend/typescript-react-apollo/tutorial-site/content/mutations-variables/3-create-mutation.md
@@ -22,7 +22,7 @@ We are importing the `useMutation` hook from `@apollo/react-hooks` and passing i
 
 ```
 
-In the `useMutation` hook defined above, the first property of the result object is the mutate function; (addTodo) in this case. Read more about the mutate function [here](https://www.apollographql.com/docs/react/essentials/mutations.html)
+In the `useMutation` hook defined above, the first property of the result object is the mutate function; (addTodo) in this case. Read more about the mutate function [here](https://www.apollographql.com/docs/react/data/mutations/)
 
 The mutate function optionally takes variables and update among other arguments; You are going to make use of the `update` function later.
 

--- a/tutorials/mobile/react-native-apollo/tutorial-site/content/mutations/2-create-mutation.md
+++ b/tutorials/mobile/react-native-apollo/tutorial-site/content/mutations/2-create-mutation.md
@@ -99,7 +99,7 @@ render() {
 }
 ```
 
-In the `<Mutation>` component defined above, the first argument of the render prop function is the mutate function(insertTodo) in this case. Read more about the mutate function [here](https://www.apollographql.com/docs/react/essentials/mutations.html#render-prop).
+In the `<Mutation>` component defined above, the first argument of the render prop function is the mutate function(insertTodo) in this case. Read more about the mutate function [here](https://www.apollographql.com/docs/react/data/mutations/).
 
 The mutate function optionally takes variables, optimisticResponse, refetchQueries, and update; You are going to make use of the `update` function later.
 

--- a/tutorials/mobile/react-native-apollo/tutorial-site/content/queries/2-create-query.md
+++ b/tutorials/mobile/react-native-apollo/tutorial-site/content/queries/2-create-query.md
@@ -183,7 +183,7 @@ When you wrapped your return with `<Query>` component, Apollo injected props int
 
 `data`: An object containing the result of your GraphQL query. This will contain our actual data from the server. In our case, it will be the todo data.
 
-You can read more about other render props that Apollo passes [here](https://www.apollographql.com/docs/react/essentials/queries.html#render-prop)
+You can read more about other render props that Apollo passes [here](https://www.apollographql.com/docs/react/data/queries/)
 
 Using the `data` prop, we are parsing the results from the server. In our query, `data` prop has an array `todos` which can be mapped over to render each `TodoItem`.
 


### PR DESCRIPTION
Closes #75

Helping out in the spirit of Hacktoberfest! :smile: 

There were several broken links to the Apollo GraphQL Docs site due to the Docs site recently changing some of their URLs.

This PR fixes those broken links so they point to the correct locations in the Apollo Docs. :+1: 