### PR TITLE
Missing public.gen_random_uuid() on public.users

### DIFF
--- a/tutorials/backend/hasura-auth-slack/slack-backend/migrations/1575954408269_slack-model-init/up.sql
+++ b/tutorials/backend/hasura-auth-slack/slack-backend/migrations/1575954408269_slack-model-init/up.sql
@@ -53,7 +53,7 @@ CREATE TABLE public.workspace_member (
     type text DEFAULT 'member'::text NOT NULL
 );
 CREATE TABLE public.users (
-    id uuid NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     name text NOT NULL,
     email text NOT NULL,
     display_name text,


### PR DESCRIPTION
Otherwise it's not possible to apply this migration in the tutorial:

mutation {
  insert_users(objects:[{name:"Praveen", email: "myemail@example.com"}]) {
    affected_rows
  }
}

// also still needs password