### PR TITLE
Auto generate uuid on insert for new entities

### DIFF
--- a/tutorials/backend/hasura-auth-slack/slack-backend/migrations/1575954408269_slack-model-init/down.sql
+++ b/tutorials/backend/hasura-auth-slack/slack-backend/migrations/1575954408269_slack-model-init/down.sql
@@ -1,0 +1,36 @@
+ALTER TABLE ONLY public.workspace DROP CONSTRAINT workspace_owner_fkey;
+ALTER TABLE ONLY public.workspace_member DROP CONSTRAINT workspace_members_workspace_id_fkey;
+ALTER TABLE ONLY public.workspace_member DROP CONSTRAINT workspace_members_user_id_fkey;
+ALTER TABLE ONLY public.workspace_member DROP CONSTRAINT workspace_member_type_fkey;
+ALTER TABLE ONLY public.user_message DROP CONSTRAINT user_message_workspace_id_fkey;
+ALTER TABLE ONLY public.user_message DROP CONSTRAINT user_message_user_id_fkey;
+ALTER TABLE ONLY public.user_message DROP CONSTRAINT user_message_recipient_id_fkey;
+ALTER TABLE ONLY public.channel DROP CONSTRAINT channels_workspace_id_fkey;
+ALTER TABLE ONLY public.channel_thread_message DROP CONSTRAINT channel_thread_message_user_id_fkey;
+ALTER TABLE ONLY public.channel_thread_message DROP CONSTRAINT channel_thread_message_channel_thread_id_fkey;
+ALTER TABLE ONLY public.channel_thread DROP CONSTRAINT channel_thread_channel_id_fkey;
+ALTER TABLE ONLY public.channel_member DROP CONSTRAINT channel_member_user_id_fkey;
+ALTER TABLE ONLY public.channel_member DROP CONSTRAINT channel_member_channel_id_fkey;
+ALTER TABLE ONLY public.workspace DROP CONSTRAINT workspace_url_slug_key;
+ALTER TABLE ONLY public.workspace DROP CONSTRAINT workspace_pkey;
+ALTER TABLE ONLY public.workspace DROP CONSTRAINT workspace_name_key;
+ALTER TABLE ONLY public.workspace_member DROP CONSTRAINT workspace_members_pkey;
+ALTER TABLE ONLY public.users DROP CONSTRAINT users_pkey;
+ALTER TABLE ONLY public.workspace_user_type DROP CONSTRAINT user_type_pkey;
+ALTER TABLE ONLY public.user_message DROP CONSTRAINT user_message_pkey;
+ALTER TABLE ONLY public.channel DROP CONSTRAINT channels_pkey;
+ALTER TABLE ONLY public.channel_thread DROP CONSTRAINT channel_thread_pkey;
+ALTER TABLE ONLY public.channel_thread_message DROP CONSTRAINT channel_thread_message_pkey;
+ALTER TABLE ONLY public.channel_member DROP CONSTRAINT channel_member_pkey;
+
+DROP VIEW IF EXISTS public.online_users;
+
+DROP TABLE IF EXISTS public.workspace_user_type;
+DROP TABLE IF EXISTS public.users;
+DROP TABLE IF EXISTS public.workspace_member;
+DROP TABLE IF EXISTS public.workspace;
+DROP TABLE IF EXISTS public.user_message;
+DROP TABLE IF EXISTS public.channel_thread_message;
+DROP TABLE IF EXISTS public.channel_thread;
+DROP TABLE IF EXISTS public.channel_member;
+DROP TABLE IF EXISTS public.channel;

--- a/tutorials/backend/hasura-auth-slack/slack-backend/migrations/1575954408269_slack-model-init/up.sql
+++ b/tutorials/backend/hasura-auth-slack/slack-backend/migrations/1575954408269_slack-model-init/up.sql
@@ -1,5 +1,7 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
 CREATE TABLE public.channel (
-    id uuid NOT NULL,
+    id uuid NOT NULL DEFAULT uuid_generate_v4(),
     name text NOT NULL,
     is_public boolean NOT NULL,
     workspace_id uuid NOT NULL,
@@ -8,20 +10,20 @@ CREATE TABLE public.channel (
     created_by uuid NOT NULL
 );
 CREATE TABLE public.channel_member (
-    id uuid NOT NULL,
+    id uuid NOT NULL DEFAULT uuid_generate_v4(),
     channel_id uuid NOT NULL,
     user_id uuid NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
 CREATE TABLE public.channel_thread (
-    id uuid NOT NULL,
+    id uuid NOT NULL DEFAULT uuid_generate_v4(),
     channel_id uuid NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
 CREATE TABLE public.channel_thread_message (
-    id uuid NOT NULL,
+    id uuid NOT NULL DEFAULT uuid_generate_v4(),
     user_id uuid NOT NULL,
     channel_thread_id uuid NOT NULL,
     message text NOT NULL,
@@ -29,7 +31,7 @@ CREATE TABLE public.channel_thread_message (
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
 CREATE TABLE public.user_message (
-    id uuid NOT NULL,
+    id uuid NOT NULL DEFAULT uuid_generate_v4(),
     user_id uuid NOT NULL,
     recipient_id uuid NOT NULL,
     message text NOT NULL,
@@ -38,7 +40,7 @@ CREATE TABLE public.user_message (
     workspace_id uuid NOT NULL
 );
 CREATE TABLE public.workspace (
-    id uuid NOT NULL,
+    id uuid NOT NULL DEFAULT uuid_generate_v4(),
     name text NOT NULL,
     owner_id uuid NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
@@ -53,7 +55,7 @@ CREATE TABLE public.workspace_member (
     type text DEFAULT 'member'::text NOT NULL
 );
 CREATE TABLE public.users (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid NOT NULL DEFAULT uuid_generate_v4(),
     name text NOT NULL,
     email text NOT NULL,
     display_name text,


### PR DESCRIPTION
This fixes a bug when trying to create the first user in this authentication tutorial.

As there was no auto-generate for the uuid, postgres would prevent insertion, based on the foreign key constraints.