### PR TITLE
typescript-react-apollo: Change npm to yarn in setup.md

### DIFF
--- a/tutorials/frontend/typescript-react-apollo/tutorial-site/content/setup.md
+++ b/tutorials/frontend/typescript-react-apollo/tutorial-site/content/setup.md
@@ -12,8 +12,8 @@ Our task will be to convert the "static" UI into a working realtime app.
 1. Download the boilerplate from https://learn.hasura.io/graphql/typescript-react-apollo/boilerplate.zip
 2. Unzip and make sure you're in the `app-boilerplate` directory
 3. Install dependencies and run the "static" app
-    - `npm install`
-    - `npm start`
+    - `yarn`
+    - `yarn start`
 4. Signup/login as a user to load the todo app page
 
 This is what you should see after the steps above:


### PR DESCRIPTION
### What I did
change `npm` to `yarn` in `tutorials/frontend/typescript-react-apollo/tutorial-site/content/setup.md`.

### Why
since [the boilerplate](https://github.com/hasura/learn-graphql/tree/master/tutorials/frontend/typescript-react-apollo/app-boilerplate) for `typescript-react-apollo` tutorial uses `yarn` as its package manager.