### PR TITLE
abruptly scroll to the target URL

### DIFF
--- a/services/homepage/src/styles/styles.scss
+++ b/services/homepage/src/styles/styles.scss
@@ -1,5 +1,9 @@
 @import url('https://fonts.googleapis.com/css?family=Poppins:300,400,500,600,700&display=swap');
 @import url('https://fonts.googleapis.com/css?family=Open+Sans:400,600&display=swap');
+html
+{
+  scroll-behavior: smooth;
+}
 body
 {
   font-size: 16px;


### PR DESCRIPTION
When I Click on item of content (shown in the image), it scroll the page to the particular section. 
Using smooth scroll we can fix this. 
![Image of Content](https://user-images.githubusercontent.com/15886737/75095636-f3c1d300-55bc-11ea-86c1-dc5af08507dc.png)
