### PR TITLE
Remove redundant ternary from Vue example

### DIFF
--- a/tutorials/frontend/vue-apollo/app-final/src/components/TodoInput.vue
+++ b/tutorials/frontend/vue-apollo/app-final/src/components/TodoInput.vue
@@ -38,7 +38,7 @@
       addTodo: function () {
         // insert new todo into db
         const title = this.newTodo && this.newTodo.trim()
-        const isPublic = this.type === "public" ? true : false;
+        const isPublic = this.type === "public";
         this.$apollo.mutate({
           mutation: ADD_TODO,
           variables: {


### PR DESCRIPTION
Minor change but I noticed it while reading the docs so thought I may as well PR a fix