### PR TITLE
Update 3-writing-data-mutations.md

### DIFF
--- a/tutorials/mobile/react-native-apollo/tutorial-site/content/intro-to-graphql/3-writing-data-mutations.md
+++ b/tutorials/mobile/react-native-apollo/tutorial-site/content/intro-to-graphql/3-writing-data-mutations.md
@@ -87,7 +87,7 @@ Now that we know how to parametrise using query variables, let's use that:
 
 ```graphql
 # The parametrised GraphQL mutation
-mutation($todo: insert_todo_input!){
+mutation($todo: todos_insert_input!){
   insert_todos(objects: [$todo]) {
     returning {
       id


### PR DESCRIPTION
The mutation of `insert_todo_input` type returns an error message of `"no such type exists in the schema: 'insert_todo_input'"`

I believe the correct mutation should be `todos_insert_input!`