### PR TITLE
Replace incorrect context.accessToken

### DIFF
--- a/tutorials/frontend/nextjs/tutorial-site/content/auth0-setup/1-custom-claims.md
+++ b/tutorials/frontend/nextjs/tutorial-site/content/auth0-setup/1-custom-claims.md
@@ -14,7 +14,7 @@ Add the following rule to add our custom JWT claims under `hasura-jwt-claim`:
 ```javascript
 function (user, context, callback) {
   const namespace = "https://hasura.io/jwt/claims";
-  context.accessToken[namespace] = 
+  context.idToken[namespace] = 
     { 
       'x-hasura-default-role': 'user',
       // do some custom logic to decide allowed roles


### PR DESCRIPTION
For this code to actually work, the guide needs to be updated to reflect `context.idToken[...` and not `context.accessToken[...`