### PR TITLE
Fix link to graphql-queries with variables

### DIFF
--- a/tutorials/graphql/intro-graphql/tutorial-site/content/graphql-mutations.md
+++ b/tutorials/graphql/intro-graphql/tutorial-site/content/graphql-mutations.md
@@ -8,7 +8,7 @@ import {Link} from "gatsby";
 
 These are the concepts you should know before you attack mutations (haha):
 - <Link to="/graphql-queries#graphiql">Using GraphiQL</Link>
-- <Link to="/graphql-queries#query-variables">Using query variables</Link>
+- <Link to="/graphql-queries#graphqlvariables:passingargumentstoyourqueriesdynamically">Using query variables</Link>
 
 Now, let's get started with seeing how we can use GraphQL to "write" data.
 GraphQL mutations are types of GraphQL queries that may result in the state


### PR DESCRIPTION
The current anchor, `#query-variables`, doesn't seem to exist any more on the page `/graphql-queries`.
The closest I could find is the anchor `#graphqlvariables:passingargumentstoyourqueriesdynamically`.