### PR TITLE
misc: fix syntax for auth0 rule

### DIFF
--- a/tutorials/backend/hasura/tutorial-site/content/authentication/4-user-sync-rule.md
+++ b/tutorials/backend/hasura/tutorial-site/content/authentication/4-user-sync-rule.md
@@ -22,7 +22,7 @@ function (user, context, callback) {
     ) {
       affected_rows
     }
-  }`
+  }`;
 
   const variables = { "userId": userId, "nickname": nickname };
 

--- a/tutorials/frontend/nextjs/tutorial-site/content/auth0-setup/3-user-sync-rule.md
+++ b/tutorials/frontend/nextjs/tutorial-site/content/auth0-setup/3-user-sync-rule.md
@@ -20,7 +20,7 @@ function (user, context, callback) {
     ) {
       affected_rows
     }
-  }`
+  }`;
 
   const variables = { "userId": userId, "nickname": nickname };
 


### PR DESCRIPTION
This PR fixes syntax for Auth0 rules (previously a semi-colon was missing which prevented users from saving the rule)