### PR TITLE
Fix typo in authorization course

### DIFF
--- a/tutorials/backend/hasura-auth-slack/tutorial-site/content/access-control/4-threads-messages-permissions.md
+++ b/tutorials/backend/hasura-auth-slack/tutorial-site/content/access-control/4-threads-messages-permissions.md
@@ -76,7 +76,7 @@ The above condition translates to the following expression:
 
 ### Column level update
 
-The user can only update the `message` column in `channel_message` table.
+The user can only update the `message` column in `channel_thread_message` table.
 
 ## Delete permission
 


### PR DESCRIPTION
Update table name from  `channel_message` to `channel_thread_message`, as the former does not exist, and the latter is correct.