### PR TITLE
fix minor typo with capitalization

### DIFF
--- a/tutorials/backend/hasura-auth-slack/tutorial-site/content/access-control/1-user-permissions.md
+++ b/tutorials/backend/hasura-auth-slack/tutorial-site/content/access-control/1-user-permissions.md
@@ -59,7 +59,7 @@ No. A user signs up on the app which goes through the auth server which deals wi
 
 Who is allowed to update the existing data in `users` table?
 
-As an authenticated user of the app, i should be able to update ONLY my own personal data.
+As an authenticated user of the app, I should be able to update ONLY my own personal data.
 
 ### Row level update
 


### PR DESCRIPTION
As per the English grammar the letter 'i' should be capitalized when referring to yourself. Refer to point 5 in [this](https://grammar.yourdictionary.com/capitalization/10-rules-of-capitalization.html) article.