### PR TITLE
Added GraphQL Introductory Tutorial Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ There are three different tutorial series:
 - [Auth with Hasura](https://hasura.io/learn/graphql/hasura-auth-slack/introduction/)
 - Postgres Basics (coming soon)
 
+#### GraphQL Basics (For complete beginners who aren't familiar with GraphQL )
+- [Intro to GraphQL](https://hasura.io/learn/graphql/intro-graphql/introduction/)
+
 ## Contributing
 
 Check out our [contributing guide](CONTRIBUTING.md) for more details.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ There are three different tutorial series:
 - [Auth with Hasura](https://hasura.io/learn/graphql/hasura-auth-slack/introduction/)
 - Postgres Basics (coming soon)
 
-#### GraphQL Basics (For complete beginners who aren't familiar with GraphQL )
+#### GraphQL Basics
 - [Intro to GraphQL](https://hasura.io/learn/graphql/intro-graphql/introduction/)
 
 ## Contributing


### PR DESCRIPTION
I have added the Intro to GraphQL Link as [https://hasura.io/learn/graphql/intro-graphql/introduction/](https://hasura.io/learn/graphql/intro-graphql/introduction/) under GraphQL Basics. It will help complete beginners who are not that much familiar with GraphQL. It will also work as a revision tutorial for those who know GraphQL a little bit but not so much confident. 
If you find it useful, then please merge the pull request. It will boost confidence as an aspiring Open Source Contributor.
Thank You. 