### PR TITLE
flutter-graphql: update graphql-client.md (close #336)

### DIFF
--- a/tutorials/mobile/flutter-graphql/tutorial-site/content/graphql-client.md
+++ b/tutorials/mobile/flutter-graphql/tutorial-site/content/graphql-client.md
@@ -65,12 +65,12 @@ To do this create a file named `client.dart` inside `lib/config` folder and add 
 
 In the above code we are creating `httpLink`, `authLink` and `websocketLink` and concatenating them to variable type `Link` link. In function named `initailizeClient` we are configuring our `client` using `GraphQLClient` widget provided by package itself and returning a instance of type `ValueNotifier<GraphQLClient>`.
 
-Now, to add GraphQL provider to our app we have to wrap our parent widget (i.e. `DefaultTabController` inside lib/screens/dashboard.dart) with `GraphQLProvider` widget. `GraphQLProvider` takes `client` and `child` as parameter and we already created a function (`initailizeClient`) which is returning `client`. To do this modify your dashboard.dart as follows
+Now, to add GraphQL provider to our app we have to wrap our parent widget (i.e. `DefaultTabController` inside lib/screens/dashboard.dart) with `GraphQLProvider` widget. `GraphQLProvider` takes `client` and `child` as parameters. As the `client` we have already created a function (`initailizeClient`) which is accept `token` as a parameter and returning `client`. To do this modify your dashboard.dart as follows.
 
 ```dart
 -  return DefaultTabController(
 +  return GraphQLProvider(
-+      client: Config.initailizeClient(),
++      client: Config.initailizeClient(token),
 +      child: CacheProvider(
 +        child: DefaultTabController(
           . . .


### PR DESCRIPTION
Fix #336 

Add missing token parameter to `Config.initailizeClient()` function in the tutorial.