### PR TITLE
intro-graphql: fix intro links to be relative instead of to github

### DIFF
--- a/tutorials/graphql/intro-graphql/tutorial-site/content/introduction.md
+++ b/tutorials/graphql/intro-graphql/tutorial-site/content/introduction.md
@@ -14,17 +14,18 @@ We will explore the fundamentals of GraphQL and what makes it especially suitabl
 
 ## Key topics and takeaways:
 
-- [Introduction to GraphQL](https://github.com/hasura/learn-graphql/blob/master/tutorials/graphql/intro-graphql/tutorial-site/content/introduction.md)
-- [What is GraphQL](https://github.com/hasura/learn-graphql/blob/master/tutorials/graphql/intro-graphql/tutorial-site/content/what-is-graphql.md)
-- [Core Concepts](https://github.com/hasura/learn-graphql/blob/master/tutorials/graphql/intro-graphql/tutorial-site/content/core-concepts.md)
-- [GraphQL vs REST, a comparison](https://github.com/hasura/learn-graphql/blob/master/tutorials/graphql/intro-graphql/tutorial-site/content/graphql-vs-rest.md)
-- [Queries](https://github.com/hasura/learn-graphql/blob/master/tutorials/graphql/intro-graphql/tutorial-site/content/graphql-queries.md)
-- [Mutations](https://github.com/hasura/learn-graphql/blob/master/tutorials/graphql/intro-graphql/tutorial-site/content/graphql-mutations.md)
-- [Subscriptions](https://github.com/hasura/learn-graphql/blob/master/tutorials/graphql/intro-graphql/tutorial-site/content/graphql-subscriptions.md)
-- [GraphQL Server and Architecture](https://github.com/hasura/learn-graphql/blob/master/tutorials/graphql/intro-graphql/tutorial-site/content/graphql-server.md)
-- [GraphQL Clients](https://github.com/hasura/learn-graphql/blob/master/tutorials/graphql/intro-graphql/tutorial-site/content/graphql-client.md)
-- [GraphQL Introspection](https://github.com/hasura/learn-graphql/blob/master/tutorials/graphql/intro-graphql/tutorial-site/content/introspection.md)
-- [What Next](https://github.com/hasura/learn-graphql/blob/master/tutorials/graphql/intro-graphql/tutorial-site/content/what-next.md)
+import {Link} from "gatsby";
+
+- <Link to="/what-is-graphql/">What is GraphQL?</Link>
+- <Link to="/graphql-vs-rest/">GraphQL vs REST</Link>
+- <Link to="/core-concepts/">Core Concepts</Link>
+- <Link to="/introspection/">Introspection</Link>
+- <Link to="/graphql-queries/">Queries</Link>
+- <Link to="/graphql-mutations/">Mutations</Link>
+- <Link to="/graphql-subscriptions/">Subscriptions</Link>
+- <Link to="/graphql-server/">GraphQL Servers</Link>
+- <Link to="/graphql-client/">GraphQL Clients</Link>
+- <Link to="/what-next/">What next?</Link>
 
 ## How long will this tutorial take?
 Less than an hour


### PR DESCRIPTION
Also some changes to the link list:
- remove the self-link
- synchronize order
- language tweaks, e.g. add question marks

(Currently, the links on https://hasura.io/learn/graphql/intro-graphql/introduction/ go to the github source files directly, e.g. to https://github.com/hasura/learn-graphql/blob/master/tutorials/graphql/intro-graphql/tutorial-site/content/what-is-graphql.md)