### PR TITLE
Improved explanation of JWT token in GraphiQL

### DIFF
--- a/tutorials/backend/hasura/tutorial-site/content/custom-business-logic/1-actions.md
+++ b/tutorials/backend/hasura/tutorial-site/content/custom-business-logic/1-actions.md
@@ -151,6 +151,8 @@ query {
 
 Remember the JWT token that we got after configuring Auth0 and testing it out? Here you also need to pass in the `Authorization` header with the same JWT token to get the right data.
 
+In GraphiQL, uncheck the `hasura-collaborator-token` header, create a new one called `Authorization` and paste this in the value `Bearer eyJhb.....`.
+
 **Note**: You need to pass in the right header values. You can pass in the Authorization header with the correct token and your Node.js server will receive the appropriate `x-hasura-user-id` value from the session variables for the API to work as expected.
 
 That's it! You have now extended the built-in GraphQL API with your custom code.


### PR DESCRIPTION
It took me a couple of minutes to figure this one out. Whereas the rest of the tutorial is very precise, this part leaves out exact instructions on how to passe the token in GraqhiQL:
- Manually add `Bearer ` upfront
- Uncheck the existing collaborator token