### PR TITLE
Fix for request body parsing

### DIFF
--- a/tutorials/backend/hasura/tutorial-site/content/custom-business-logic/1-actions.md
+++ b/tutorials/backend/hasura/tutorial-site/content/custom-business-logic/1-actions.md
@@ -80,7 +80,7 @@ const getProfileInfo = (user_id) => {
 app.post('/auth0', async (req, res) => {
 
   // get request input
-  const { session_variables } = req.body;
+  const session_variables = req.body;
   
   const user_id = session_variables['x-hasura-user-id'];
   // make a rest api call to auth0


### PR DESCRIPTION
The original code does not work with a simple curl (user id masked)
```bash
curl --request POST \
--url https://auth0-hasura-action.glitch.me/auth0 \
--header 'content-type: application/json' \
--data '{ "x-hasura-user-id": "auth0|XXXXXXXXXXXXX" }'
```
it fails with `TypeError: Cannot read property 'x-hasura-user-id' of undefined` error.

As `session_variables` is already an object, so it is good to remove "{}" from line 83 and read 'x-hasura-user-id' afterwards.