### PR TITLE
Put apolloClient in App component state.

### DIFF
--- a/tutorials/frontend/react-apollo-hooks/tutorial-site/content/apollo-client.md
+++ b/tutorials/frontend/react-apollo-hooks/tutorial-site/content/apollo-client.md
@@ -87,7 +87,7 @@ const App = ({ idToken }) => {
   if (loading) {
     return <div>Loading...</div>;
   }
-+  const client = createApolloClient(idToken);
++  const [client] = useState(createApolloClient(idToken));
    return (
 +    <ApolloProvider client={client}>
        <div>


### PR DESCRIPTION
I had an issue with my application not using the cache at all when following this tutorial. Turned out it was because a new Apollo client (and a new empty cache) is created on every render if you do it as written. Putting the client in component state with `useState` solved the problem.