### PR TITLE
Update 1-todos-table-permissions.md

### DIFF
--- a/tutorials/backend/hasura/tutorial-site-ja/content/authorization/1-todos-table-permissions.md
+++ b/tutorials/backend/hasura/tutorial-site-ja/content/authorization/1-todos-table-permissions.md
@@ -49,7 +49,7 @@ import YoutubeEmbed from "../../src/YoutubeEmbed.js";
 
 「update(更新)」権限の編集アイコンをクリックします。 カスタムチェックで `With same custom checks as insert` を選択します。
 
-カラムの更新権限の下で、`id` カラムと `is_completed` カラムを選択します。
+カラムの更新権限の下で、`is_completed` カラムを選択します。
 
 ![Todos update permission](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/todos-update-permission.png)
 


### PR DESCRIPTION
The image and [the English version](https://github.com/hasura/learn-graphql/blob/775b539074bfd476886c4e6d326875dbe0a03c80/tutorials/backend/hasura/tutorial-site/content/authorization/1-todos-table-permissions.md#L52) don't have `id`.