### PR TITLE
Rename hasura-collaborator-token to x-hasura-admin-secret

### DIFF
--- a/tutorials/backend/hasura/tutorial-site/content/custom-business-logic/1-actions.md
+++ b/tutorials/backend/hasura/tutorial-site/content/custom-business-logic/1-actions.md
@@ -151,7 +151,7 @@ query {
 
 Remember the JWT token that we got after [configuring Auth0 and testing it out](https://hasura.io/learn/graphql/hasura/authentication/5-test-with-headers/)? Here you also need to pass in the `Authorization` header with the same JWT token to get the right data.
 
-In GraphiQL, uncheck the `hasura-collaborator-token` header, create a new one called `Authorization` and paste this in the value `Bearer eyJhb.....`.
+In GraphiQL, uncheck the `x-hasura-admin-secret` header, create a new one called `Authorization` and paste this in the value `Bearer eyJhb.....`.
 
 **Note**: You need to pass in the right header values. You can pass in the Authorization header with the correct token and your Node.js server will receive the appropriate `x-hasura-user-id` value from the session variables for the API to work as expected.
 


### PR DESCRIPTION
Currently(2021-5-20) admin-token name is `x-hasura-admin-secret` in the header, so I rename it in the tutorial.
![スクリーンショット 2021-05-20 20 08 07](https://user-images.githubusercontent.com/38467746/118969056-98d98000-b9a7-11eb-96ce-57c5b3384672.png)
