### PR TITLE
fix(tutorials): updateLastSeen race condition

### DIFF
--- a/tutorials/frontend/angular-apollo/app-final/src/app/OnlineUsers/OnlineUsersWrapper.ts
+++ b/tutorials/frontend/angular-apollo/app-final/src/app/OnlineUsers/OnlineUsersWrapper.ts
@@ -38,7 +38,7 @@ export class OnlineUsersWrapper implements OnInit, OnDestroy {
   constructor(private apollo: Apollo) { }
 
   ngOnInit() {
-    this.onlineIndicator = setInterval(() => this.updateLastSeen(), 30000);
+    this.onlineIndicator = setInterval(() => this.updateLastSeen(), 20000);
     this.querySubscription = this.apollo
       .subscribe<GetOnlineUsersSub>({
         query: SUBSCRIBE_TO_ONLINE_USERS,

--- a/tutorials/frontend/angular-apollo/tutorial-site/content/subscriptions.md
+++ b/tutorials/frontend/angular-apollo/tutorial-site/content/subscriptions.md
@@ -55,8 +55,8 @@ export class OnlineUsersWrapper implements OnInit {
       constructor(private apollo: Apollo) {}
 
 +      ngOnInit(){
-+        // Every 30s, run a mutation to tell the backend that you're online
-+        this.onlineIndicator = setInterval(() => this.updateLastSeen(), 30000);
++        // Every 20s, run a mutation to tell the backend that you're online
++        this.onlineIndicator = setInterval(() => this.updateLastSeen(), 20000);
 +      }
 
 ```
@@ -68,8 +68,8 @@ export class OnlineUsersWrapper implements OnInit {
       ...
 
       ngOnInit(){
-        // Every 30s, run a mutation to tell the backend that you're online
-        this.onlineIndicator = setInterval(() => this.updateLastSeen(), 30000);
+        // Every 20s, run a mutation to tell the backend that you're online
+        this.onlineIndicator = setInterval(() => this.updateLastSeen(), 20000);
      }
 
 +     updateLastSeen() {

--- a/tutorials/frontend/angular-apollo/tutorial-site/content/subscriptions/3-create-subscription.md
+++ b/tutorials/frontend/angular-apollo/tutorial-site/content/subscriptions/3-create-subscription.md
@@ -55,7 +55,7 @@ export class OnlineUsersWrapper implements OnInit {
 + loading = true;
   constructor(private apollo: Apollo) {}
   ngOnInit(){
-    this.onlineIndicator = setInterval(() => this.updateLastSeen(), 30000);
+    this.onlineIndicator = setInterval(() => this.updateLastSeen(), 20000);
 +   this.apollo.subscribe<GetOnlineUsersSub>({
 +     query: SUBSCRIBE_TO_ONLINE_USERS,
 +   }).subscribe(({ data }) => {

--- a/tutorials/frontend/nextjs/app-final/components/OnlineUsers/OnlineUsersWrapper.js
+++ b/tutorials/frontend/nextjs/app-final/components/OnlineUsers/OnlineUsersWrapper.js
@@ -21,9 +21,9 @@ const OnlineUsersWrapper = () => {
   let onlineUsersList;
 
   useEffect(() => {
-    // Every 30s, run a mutation to tell the backend that you're online
+    // Every 20s, run a mutation to tell the backend that you're online
     updateLastSeen();
-    setOnlineIndicator(setInterval(() => updateLastSeen(), 30000));
+    setOnlineIndicator(setInterval(() => updateLastSeen(), 20000));
 
     return () => {
       // Clean up

--- a/tutorials/frontend/nextjs/tutorial-site/content/subscriptions.md
+++ b/tutorials/frontend/nextjs/tutorial-site/content/subscriptions.md
@@ -43,9 +43,9 @@ const OnlineUsersWrapper = () => {
 +  const [onlineIndicator, setOnlineIndicator] = useState(0);
 +  let onlineUsersList;
 +  useEffect(() => {
-+     // Every 30s, run a mutation to tell the backend that you're online
++     // Every 20s, run a mutation to tell the backend that you're online
 +     updateLastSeen();
-+     setOnlineIndicator(setInterval(() => updateLastSeen(), 30000));
++     setOnlineIndicator(setInterval(() => updateLastSeen(), 20000));
 + 
 +     return () => {
 +       // Clean up
@@ -62,9 +62,9 @@ const OnlineUsersWrapper = () => {
   let onlineUsersList;
 
   useEffect(() => {
-    // Every 30s, run a mutation to tell the backend that you're online
+    // Every 20s, run a mutation to tell the backend that you're online
     updateLastSeen();
-    setOnlineIndicator(setInterval(() => updateLastSeen(), 30000));
+    setOnlineIndicator(setInterval(() => updateLastSeen(), 20000));
 
     return () => {
       // Clean up

--- a/tutorials/frontend/react-apollo-hooks/app-final/src/components/OnlineUsers/OnlineUsersWrapper.js
+++ b/tutorials/frontend/react-apollo-hooks/app-final/src/components/OnlineUsers/OnlineUsersWrapper.js
@@ -8,9 +8,9 @@ const OnlineUsersWrapper = () => {
   let onlineUsersList;
 
   useEffect(() => {
-    // Every 30s, run a mutation to tell the backend that you're online
+    // Every 20s, run a mutation to tell the backend that you're online
     updateLastSeen();
-    setOnlineIndicator(setInterval(() => updateLastSeen(), 30000));
+    setOnlineIndicator(setInterval(() => updateLastSeen(), 20000));
 
     return () => {
       // Clean up

--- a/tutorials/frontend/react-apollo-hooks/tutorial-site/content/subscriptions.md
+++ b/tutorials/frontend/react-apollo-hooks/tutorial-site/content/subscriptions.md
@@ -42,9 +42,9 @@ const OnlineUsersWrapper = () => {
 +  const [onlineIndicator, setOnlineIndicator] = useState(0);
 +  let onlineUsersList;
 +  useEffect(() => {
-+     // Every 30s, run a mutation to tell the backend that you're online
++     // Every 20s, run a mutation to tell the backend that you're online
 +     updateLastSeen();
-+     setOnlineIndicator(setInterval(() => updateLastSeen(), 30000));
++     setOnlineIndicator(setInterval(() => updateLastSeen(), 20000));
 + 
 +     return () => {
 +       // Clean up
@@ -61,9 +61,9 @@ const OnlineUsersWrapper = () => {
   let onlineUsersList;
 
   useEffect(() => {
-    // Every 30s, run a mutation to tell the backend that you're online
+    // Every 20s, run a mutation to tell the backend that you're online
     updateLastSeen();
-    setOnlineIndicator(setInterval(() => updateLastSeen(), 30000));
+    setOnlineIndicator(setInterval(() => updateLastSeen(), 20000));
 
     return () => {
       // Clean up

--- a/tutorials/frontend/react-apollo/app-final/src/components/OnlineUsers/OnlineUsersWrapper.js
+++ b/tutorials/frontend/react-apollo/app-final/src/components/OnlineUsers/OnlineUsersWrapper.js
@@ -25,9 +25,9 @@ class OnlineUsersWrapper extends Component {
   }
 
   componentDidMount() {
-    // Every 30s, run a mutation to tell the backend that you're online
+    // Every 20s, run a mutation to tell the backend that you're online
     this.updateLastSeen();
-    this.onlineIndicator = setInterval(() => this.updateLastSeen(), 30000);
+    this.onlineIndicator = setInterval(() => this.updateLastSeen(), 20000);
   }
 
   componentWillUnmount() {

--- a/tutorials/frontend/react-apollo/tutorial-site/content/subscriptions.md
+++ b/tutorials/frontend/react-apollo/tutorial-site/content/subscriptions.md
@@ -67,8 +67,8 @@ class OnlineUsersWrapper extends Component {
     this.client = props.client;
   }
 + componentDidMount() {
-+   // Every 30s, run a mutation to tell the backend that you're online
-+   this.onlineIndicator = setInterval(() => this.updateLastSeen(), 30000);
++   // Every 20s, run a mutation to tell the backend that you're online
++   this.onlineIndicator = setInterval(() => this.updateLastSeen(), 20000);
 + }
 ```
 
@@ -94,8 +94,8 @@ class OnlineUsersWrapper extends Component {
 +    });
 +  }
   componentDidMount() {
-    // Every 30s, run a mutation to tell the backend that you're online
-    this.onlineIndicator = setInterval(() => this.updateLastSeen(), 30000);
+    // Every 20s, run a mutation to tell the backend that you're online
+    this.onlineIndicator = setInterval(() => this.updateLastSeen(), 20000);
   }
 ```
 


### PR DESCRIPTION
Decrease the polling time of the frontend from 30s to 20s
to avoid race conditions between backend/frontend due to
network latency.

Closes #435