### PR TITLE
Save docker-compose configuration as compose.yaml

### DIFF
--- a/tutorials/database/postgresql/tutorial-site/content/installation/installing-postgresql.md
+++ b/tutorials/database/postgresql/tutorial-site/content/installation/installing-postgresql.md
@@ -10,7 +10,7 @@ Before we dive in to the core concepts, we will install Postgres on the local ma
 
 We can make use of docker-compose to install Postgres locally
 
-Create a new file called `postgres.yaml` and copy the contents below:
+Create a new file called `compose.yaml` and copy the contents below:
 
 ```yaml
 version: '3.6'


### PR DESCRIPTION
Following the docs as written I got the error
```
$ docker-compose up -d
ERROR: 
        Can't find a suitable configuration file in this directory or any
        parent. Are you in the right directory?

        Supported filenames: docker-compose.yml, docker-compose.yaml, compose.yml, compose.yaml
```
Other option naturally would be to change the command to run to include the filename as written  `docker-compose -f postgres.yaml up`, but this feels more straightforward. 

Thank you for the tutorials!