### PR TITLE
Reorganised information (fix #479)

### DIFF
--- a/tutorials/frontend/typescript-react-apollo/tutorial-site/content/codegen.md
+++ b/tutorials/frontend/typescript-react-apollo/tutorial-site/content/codegen.md
@@ -95,7 +95,6 @@ Replace xxxxx with the Auth Token you copied from GraphiQL. The Auth Token shoul
 
 _Note_: The command is likely to throw an error until a query, mutation or subscription is defined in the project. You will add them in the next steps and the error will disappear.
 
-
 This script is running in `watch` mode and hence will autogenerate types for any queries/mutations/subscriptions that are added later in the tutorial.
 
 Once they are added two files will be generated:

--- a/tutorials/frontend/typescript-react-apollo/tutorial-site/content/codegen.md
+++ b/tutorials/frontend/typescript-react-apollo/tutorial-site/content/codegen.md
@@ -91,7 +91,10 @@ $env:AUTH_TOKEN="xxxxx"
 yarn generate --watch
 ```
 
-_Note_: Replace xxxxx with the Auth Token you copied from GraphiQL. The Auth Token shouldn't have `Bearer`
+Replace xxxxx with the Auth Token you copied from GraphiQL. The Auth Token shouldn't have `Bearer`.
+
+_Note_: The command is likely to throw an error until a query, mutation or subscription is defined in the project. You will add them in the next steps and the error will disappear.
+
 
 This script is running in `watch` mode and hence will autogenerate types for any queries/mutations/subscriptions that are added later in the tutorial.
 
@@ -99,8 +102,6 @@ Once they are added two files will be generated:
 
 1. `graphql.schema.json` - Introspection result of the GraphQL server goes into this file in JSON format.
 2. `src/generated/graphql.tsx` - It will generate the necessary types for mapping GraphQL queries to Typescript.
-
-_Note_: The command is likely to throw an error until a query, mutation or subscription is defined in the project.
 
 We will import the generated GraphQL types in different parts of the tutorial and see how it helps with type safety and how much hand written code is avoided.
 


### PR DESCRIPTION
Running the command to generate the types throws an error because it cannot find any query, mutation or subscription in the project. However, when you add them in the next steps, the error goes away.

There is a warning note in the documentation specifying this, but many people miss it because it's down the page. I moved the note higher on the page, under the command, so it's more visible.

P.S: Sorry for the commit message. I put the quotes wrongly in the commit command.