### PR TITLE
fix(data-mutations): replace created with created_at to remove error …

### DIFF
--- a/tutorials/mobile/react-native-apollo/tutorial-site/content/intro-to-graphql/3-writing-data-mutations.md
+++ b/tutorials/mobile/react-native-apollo/tutorial-site/content/intro-to-graphql/3-writing-data-mutations.md
@@ -68,7 +68,7 @@ mutation {
       title
       is_completed
       is_public
-      created
+      created_at
     }
   }
 }


### PR DESCRIPTION
…in mobile tutorial

When I followed the [mobile RN tutorial](https://hasura.io/learn/graphql/react-native/intro-to-graphql/3-writing-data-mutations/), I encountered an error that ended up blocking the progress.

**Before**
<img width="1116" alt="Screen Shot 2022-03-01 at 5 42 01 PM" src="https://user-images.githubusercontent.com/42548220/156261277-30cdf9be-c930-42f1-9571-804f15fce7bb.png">

Replacing the `created` with `created_at` seems to fix the issue.
**After**
<img width="1111" alt="Screen Shot 2022-03-01 at 5 42 19 PM" src="https://user-images.githubusercontent.com/42548220/156261344-f891e56f-b4aa-4b62-bdfb-0b4d9dfcf84f.png">

I also browsed the files for other tutorials and I found that this is the only file that had this typo so no need to look for other files.
