### PR TITLE
corrected example for workspace members

### DIFF
--- a/tutorials/backend/hasura-auth-slack/tutorial-site/content/access-control/1-user-permissions.md
+++ b/tutorials/backend/hasura-auth-slack/tutorial-site/content/access-control/1-user-permissions.md
@@ -33,8 +33,12 @@ The expanded valid boolean expression of the above statement looks like this:
     },
     {
       "workspace_members": {
-        "user_id": {
-          "_eq": "X-Hasura-User-Id"
+        "workspace": {
+          "workspace_members": {
+            "user_id": {
+              "_eq": "X-Hasura-User-Id"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Explanation: the relationships from the `users` table to the `workspace_members` table happens via the `user_id`, which means both branches of the `or` statement are the same.

The corrected example will navigate to the `workspace` table first, then back to the `workspace_members` table.
Because that relationship happens via the workspace id, the result will include all workspace members.