### PR TITLE
Change "Modify Page" to "Modify"

### DIFF
--- a/tutorials/backend/hasura/tutorial-site/content/relationships/1-create-foreign-key.md
+++ b/tutorials/backend/hasura/tutorial-site/content/relationships/1-create-foreign-key.md
@@ -10,7 +10,7 @@ In the `todos` table, the value of `user_id` column must be ideally present in t
 
 Let's define one for the `user_id` column in `todos` table.
 
-Head over to Console -> DATA -> todos -> Modify page.
+Head over to Console -> DATA -> todos -> Modify.
 
 It should look something like this:
 


### PR DESCRIPTION
The tutorial has the word 'Modify Page', but interface shows 'Modify"

Suggest removing 'Page' so that the tutorial matches the name used in the console.