### PR TITLE
node example missing critical info on how to run

### DIFF
--- a/tutorials/backend/backend-stack/source-code/node/README.md
+++ b/tutorials/backend/backend-stack/source-code/node/README.md
@@ -1,3 +1,11 @@
+Have docker installed on your machine then run the following:
+
+```bash
+docker compose --file docker-compose.yml up --detach
+```
+
+Then:
+
 ```bash
 npm install
 

--- a/tutorials/backend/backend-stack/source-code/node/package.json
+++ b/tutorials/backend/backend-stack/source-code/node/package.json
@@ -15,7 +15,8 @@
     "express": "^4.18.2",
     "graphql": "^16.6.0",
     "graphql-request": "^5.0.0",
-    "graphql-yoga": "^2.13.13"
+    "@graphql-yoga/node": "^2.13.13",
+    "@graphql-typed-document-node/core": "^3.1.1"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "2.13.7",


### PR DESCRIPTION
1. It's not possible to run the node example by following the existing [`README.md`](https://github.com/hasura/learn-graphql/blob/master/tutorials/backend/backend-stack/source-code/node/README.md). I added info on prerequisite `docker compose` step,
2. Updated GraphQL Yoga package name to match what the [official repo recommends](https://github.com/dotansimha/graphql-yoga#installation): `@graphql-yoga/node`,
3. Added missing package: `@graphql-typed-document-node/core`.