### PR TITLE
Fixed constraint for age >= 18

### DIFF
--- a/tutorials/database/mysql/tutorial-site/content/core-concepts/4-mysql-constraints.md
+++ b/tutorials/database/mysql/tutorial-site/content/core-concepts/4-mysql-constraints.md
@@ -61,7 +61,7 @@ The CHECK constraint verifies the value in a particular column. It ensures that 
 CREATE TABLE Persons(
 ID int NOT NULL,
 Name varchar(45) NOT NULL,
-Age int CHECK (Age=18)
+Age int CHECK (Age>=18)
 );
 ```
 


### PR DESCRIPTION
It should have been `>=` but `=` was used so fixed it.