### PR TITLE
docs: add backlinks to Hasura Basics tutorial

### DIFF
--- a/tutorials/backend/hasura/tutorial-site/content/authentication.md
+++ b/tutorials/backend/hasura/tutorial-site/content/authentication.md
@@ -4,7 +4,7 @@ metaTitle: "Authentication with Hasura | Hasura GraphQL Tutorial"
 metaDescription: "This part of the tutorial covers how to do Authentication in Hasura GraphQL Engine by integrating with an Authentication provider like Auth0"
 ---
 
-In this part, we will look at how to integrate an Authentication provider.
+In this part, we will look at how to integrate an [Authentication](https://hasura.io/docs/latest/auth/authentication/index/) provider.
 
 The realtime todo app needs to be protected by a login interface. We are going to use [Auth0](https://auth0.com) as the identity/authentication provider for this example.
 

--- a/tutorials/backend/hasura/tutorial-site/content/authorization.md
+++ b/tutorials/backend/hasura/tutorial-site/content/authorization.md
@@ -4,7 +4,7 @@ metaTitle: "Authorization with Hasura | Hasura GraphQL Tutorial"
 metaDescription: "This part of the tutorial covers how to do Authorization in Hasura GraphQL Engine by defining role-based access control rules for the models."
 ---
 
-In this part of the tutorial, we are going to define role-based access control rules for each of the models that we created.
+In this part of the tutorial, we are going to define [role-based access control](https://hasura.io/docs/latest/auth/authorization/index/) rules for each of the models that we created.
 
 Access control rules help in restricting querying on a table based on certain conditions.
 

--- a/tutorials/backend/hasura/tutorial-site/content/custom-business-logic.md
+++ b/tutorials/backend/hasura/tutorial-site/content/custom-business-logic.md
@@ -23,7 +23,7 @@ Actions can be either a Query or a Mutation.
 Remote Schemas {#remote-schemas}
 --------------
 
-Hasura has the ability to merge remote GraphQL schemas and provide a unified GraphQL API. Think of it like automated schema stitching. This way, we can write custom GraphQL resolvers and add it as a remote schema.
+Hasura's [Remote Schema](https://hasura.io/docs/latest/remote-schemas/index/) feature provides the ability to merge remote GraphQL schemas and provide a unified GraphQL API. Think of it like automated schema stitching. This way, we can write custom GraphQL resolvers and add it as a remote schema.
 
 ![Remote schema architecture](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/remote-schema-architecture.png)
 
@@ -35,7 +35,7 @@ If you are choosing between Actions and Remote Schemas, here's something to keep
 Event Triggers {#event-triggers}
 --------------
 
-Hasura can be used to [create event triggers on tables in the Postgres database](https://hasura.io/learn/database/postgresql/triggers/). Event triggers reliably capture events on specified tables and invoke webhooks to carry out any custom logic. After a mutation operation, triggers can call a webhook asynchronously.
+Hasura can be used to [create event triggers on tables in the Postgres database](https://hasura.io/learn/database/postgresql/triggers/). [Event Triggers](https://hasura.io/docs/latest/event-triggers/index/) reliably capture events on specified tables and invoke webhooks to carry out any custom logic. After a mutation operation, triggers can call a webhook asynchronously.
 
 Use case for the todo app {#use-case-todo-app}
 -------------------------

--- a/tutorials/backend/hasura/tutorial-site/content/data-modeling.md
+++ b/tutorials/backend/hasura/tutorial-site/content/data-modeling.md
@@ -4,7 +4,7 @@ metaTitle: "Data Modeling with Hasura | Hasura GraphQL Tutorial"
 metaDescription: "This tutorial covers how to do data modeling in Postgres and create tables using Hasura console"
 ---
 
-In this part of the course, we will build the data model for a realtime todo app. Our todo app will have the following features:
+In this part of the course, we will build the [data model](https://hasura.io/docs/latest/schema/common-patterns/data-modeling/index/) for a realtime todo app. Our todo app will have the following features:
 
 - Users can maintain personal todos
 - Users can view public todos

--- a/tutorials/backend/hasura/tutorial-site/content/data-modeling/2-try-user-queries.md
+++ b/tutorials/backend/hasura/tutorial-site/content/data-modeling/2-try-user-queries.md
@@ -12,7 +12,7 @@ You can access GraphiQL by heading over to Console -> API -> GraphiQL tab.
 
 ## Mutation {#mutation}
 
-Let's add a user using a GraphQL Mutation. Copy the following code into the GraphiQL interface.
+Let's add a user using a [GraphQL Mutation](https://hasura.io/docs/latest/mutations/index/). Copy the following code into the GraphiQL interface.
 
 ```graphql
 mutation {
@@ -34,7 +34,7 @@ Great! You have now consumed the mutation query for the `users` table that you j
 
 ## Query {#query}
 
-Now let's go ahead and query the data that we just inserted.
+Now let's go ahead and [query](https://hasura.io/docs/latest/queries/index/) the data that we just inserted.
 
 ```graphql
 query {
@@ -54,7 +54,7 @@ Note that some columns like `created_at` have default values, even though you di
 
 ## Subscription {#subscription}
 
-Let's run a subscription query over `users` table to watch for changes to the table.
+Let's run a [subscription](https://hasura.io/docs/latest/subscriptions/index/) query over `users` table to watch for changes to the table.
 
 ```graphql
 subscription {

--- a/tutorials/backend/hasura/tutorial-site/content/data-modeling/2-try-user-queries.md
+++ b/tutorials/backend/hasura/tutorial-site/content/data-modeling/2-try-user-queries.md
@@ -12,7 +12,7 @@ You can access GraphiQL by heading over to Console -> API -> GraphiQL tab.
 
 ## Mutation {#mutation}
 
-Let's add a user using a [GraphQL Mutation](https://hasura.io/docs/latest/mutations/index/). Copy the following code into the GraphiQL interface.
+Let's add a user using a [GraphQL Mutation](https://hasura.io/learn/graphql/intro-graphql/graphql-queries/). Copy the following code into the GraphiQL interface.
 
 ```graphql
 mutation {

--- a/tutorials/backend/hasura/tutorial-site/content/data-transformations.md
+++ b/tutorials/backend/hasura/tutorial-site/content/data-transformations.md
@@ -12,7 +12,7 @@ So far we were building tables and relationships.
 [Postgres](https://hasura.io/learn/database/postgresql/what-is-postgresql/) allows you to perform data transformations using:
 
 - [Views](https://hasura.io/learn/database/postgresql/views/)
-- SQL Functions
+- [SQL Functions](https://hasura.io/docs/latest/schema/postgres/custom-functions/)
 
 In this example, we are going to make use of `Views`. This view is required by the app to find the users who have logged in and are online in the last 30 seconds.
 

--- a/tutorials/backend/hasura/tutorial-site/content/introduction.md
+++ b/tutorials/backend/hasura/tutorial-site/content/introduction.md
@@ -6,7 +6,7 @@ metaDescription: "A powerful and concise tutorial that will introduce you to set
 
 This course is a super-fast introduction to setting up a GraphQL backend with Hasura.
 
-In 30 mins, you will set up a Powerful, Scalable Realtime GraphQL Backend complete with Queries, Mutations, and Subscriptions. You will also learn how Hasura helps you integrate custom business logic (in any programming language), both as custom GraphQL APIs that you write yourself, and as Event Triggers that run asynchronously and are triggered by database events.
+In 30 mins, you will set up a Powerful, Scalable Realtime GraphQL Backend complete with Queries, Mutations, and Subscriptions. You will also learn how Hasura helps you integrate custom business logic (in any programming language), both as custom GraphQL APIs that you write yourself, and as [Event Triggers](https://hasura.io/docs/latest/event-triggers/index/) that run asynchronously and are triggered by database events.
 
 ## What will I learn? {#what-will-i-learn}
 

--- a/tutorials/backend/hasura/tutorial-site/content/relationships.md
+++ b/tutorials/backend/hasura/tutorial-site/content/relationships.md
@@ -8,8 +8,8 @@ Relationships enable you to make nested object queries if the tables/views in yo
 
 GraphQL schema relationships can be either of
 
-- object relationships (one-to-one)
-- array relationships (one-to-many)
+- [object relationships (one-to-one)](https://hasura.io/docs/latest/schema/common-patterns/data-modeling/one-to-one/)
+- [array relationships (one-to-many)](https://hasura.io/docs/latest/schema/common-patterns/data-modeling/one-to-many/)
 
 ## Object Relationships {#object-relationships}
 


### PR DESCRIPTION
Covering [DOCS-191](https://hasurahq.atlassian.net/browse/DOCS-191?atlOrigin=eyJpIjoiYzBhNTBjMDU3YjUxNDUyNTg3NDRhZDUwNTM3M2E4MzMiLCJwIjoiaiJ9), this PR is the first in a series that will address docs backlinking in Learn tutorials. 

**NB: I made a deliberate effort to do the additions sparingly. The flow of these tutorials is critical, and any links that move a user away while going step-by-step distract from the tutorial's goal. As such, any docs additions are strategic and included only where a user may need some more context as they're introduced to a concept for the first time.**