### PR TITLE
docs: add backlinks to Hasura Auth tutorials

### DIFF
--- a/tutorials/backend/hasura-auth-slack/tutorial-site/content/access-control.md
+++ b/tutorials/backend/hasura-auth-slack/tutorial-site/content/access-control.md
@@ -4,7 +4,7 @@ metaTitle: "Authorization with Hasura | Hasura Auth Slack Tutorial"
 metaDescription: "This part of the tutorial covers how to do Authorization in Hasura GraphQL Engine by defining role based access control rules for the models."
 ---
 
-In this part of the tutorial, we are going to define role based access control rules for each of the models that we created. Access control rules help in restricting querying on a table based on certain conditions.
+In this part of the tutorial, we are going to define role based access control rules for each of the models that we created. [Access control rules help](https://hasura.io/docs/latest/auth/authorization/permission-rules/) in restricting querying on a table based on certain conditions.
 
 Access control rules can be applied on
 

--- a/tutorials/backend/hasura-auth-slack/tutorial-site/content/choosing-jwt-mode.md
+++ b/tutorials/backend/hasura-auth-slack/tutorial-site/content/choosing-jwt-mode.md
@@ -4,14 +4,14 @@ metaTitle: "Authentication Modes | Hasura Auth Slack Tutorial"
 metaDescription: "This part of the tutorial covers how to choose the right auth mode"
 ---
 
-In this part, we will look at the different modes for Authentication. Authentication is handled outside of Hasura. You can bring in your own Auth server and integrate it with Hasura. There are broadly two options available.
+In this part, we will look at the different modes for [Authentication](https://hasura.io/docs/latest/auth/authentication/index/). Authentication is handled outside of Hasura. You can bring in your own Auth server and integrate it with Hasura. There are broadly two options available.
 
 - JWT Mode
 - Webhook Mode
 
 ## JWT Mode {#jwt-mode}
 
-You can configure GraphQL Engine to use the JWT authorization mode to authorize all incoming requests. The auth server is expected to return a valid JWT token, which are decoded and verified by the GraphQL engine, to authorize and get metadata about the request.
+You can configure GraphQL Engine to use the [JWT authorization mode](https://hasura.io/docs/latest/auth/authentication/jwt/) to authorize all incoming requests. The auth server is expected to return a valid JWT token, which are decoded and verified by the GraphQL engine, to authorize and get metadata about the request.
 
 A typical architecture with Auth server issuing JWT looks like the one below:
 
@@ -21,7 +21,7 @@ The Auth Server issues JWT tokens with relevant `x-hasura-*` claims to the app w
 
 ## Webhook Mode {#webhook-mode}
 
-You can also configure GraphQL Engine to use the Webhook mode. Your auth server exposes a webhook that is used to authenticate all incoming requests to the Hasura GraphQL engine server and to get metadata about the request to evaluate access control rules.
+You can also configure GraphQL Engine to use the [Webhook mode](https://hasura.io/docs/latest/auth/authentication/webhook/). Your auth server exposes a webhook that is used to authenticate all incoming requests to the Hasura GraphQL engine server and to get metadata about the request to evaluate access control rules.
 
 The architecture with webhook looks like the one below:
 
@@ -29,4 +29,4 @@ The architecture with webhook looks like the one below:
 
 ### Unauthenticated Mode {#unauthenticated-mode}
 
-Sometimes you would like to allow access to data without a user being logged in. This is useful for public feed which is open to all users. Although our Slack app doesn't have this as a use case, it is good to know when this could be used.
+Sometimes you would like to allow (access to data without a user being logged in)[https://hasura.io/docs/latest/auth/authentication/unauthenticated-access/]. This is useful for public feed which is open to all users. Although our Slack app doesn't have this as a use case, it is good to know when this could be used.

--- a/tutorials/backend/hasura-auth-slack/tutorial-site/content/data-modeling.md
+++ b/tutorials/backend/hasura-auth-slack/tutorial-site/content/data-modeling.md
@@ -4,7 +4,7 @@ metaTitle: "Slack Data Modeling with Hasura | Hasura Auth Slack Tutorial"
 metaDescription: "This tutorial covers how to do data modeling in Postgres and create tables using Hasura console for a Slack Clone"
 ---
 
-In this part of the course, we will build the data model for a realtime slack clone. Our slack app will have the following basic features:
+In this part of the course, we will build the [data model](https://hasura.io/docs/latest/schema/common-patterns/data-modeling/index/) for a realtime slack clone. Our slack app will have the following basic features:
 
 - Users can signup.
 - Users can create workspaces.

--- a/tutorials/backend/hasura-auth-slack/tutorial-site/content/data-modeling/2-relationships.md
+++ b/tutorials/backend/hasura-auth-slack/tutorial-site/content/data-modeling/2-relationships.md
@@ -8,8 +8,8 @@ Relationships enable you to make nested object queries if the tables/views in yo
 
 GraphQL schema relationships can be either of
 
-- object relationships (one-to-one)
-- array relationships (one-to-many)
+- [object relationships (one-to-one)](https://hasura.io/docs/latest/schema/common-patterns/data-modeling/one-to-one/)
+- [array relationships (one-to-many)](https://hasura.io/docs/latest/schema/common-patterns/data-modeling/one-to-many/)
 
 ## Object Relationships {#object-relationships}
 

--- a/tutorials/backend/hasura-auth-slack/tutorial-site/content/data-modeling/3-apply-migrations.md
+++ b/tutorials/backend/hasura-auth-slack/tutorial-site/content/data-modeling/3-apply-migrations.md
@@ -38,7 +38,7 @@ endpoint: https://ready-panda-91.hasura.app
 
 **Note:** Your endpoint will be different based on your Hasura project.
 
-Now let's apply the migrations.
+Now let's apply the [migrations](https://hasura.io/docs/latest/migrations-metadata-seeds/manage-migrations/).
 
 ```bash
 hasura metadata apply --admin-secret xxxx

--- a/tutorials/backend/hasura-auth-slack/tutorial-site/content/data-modeling/4-try-queries.md
+++ b/tutorials/backend/hasura-auth-slack/tutorial-site/content/data-modeling/4-try-queries.md
@@ -10,7 +10,7 @@ Let's go ahead and start exploring the GraphQL APIs for `users` table.
 
 ## Mutation {#mutation}
 
-Head over to Console -> GRAPHIQL tab and insert a user using GraphQL Mutations.
+Head over to Console -> GRAPHIQL tab and insert a user using [GraphQL Mutations](https://hasura.io/docs/latest/mutations/index/).
 
 ```graphql
 mutation {
@@ -40,7 +40,7 @@ Great! You have now consumed the mutation query for the `users` table that you j
 
 ## Query {#query}
 
-Now let's go ahead and query the data that we just inserted.
+Now let's go ahead and [query](https://hasura.io/docs/latest/queries/index/) the data that we just inserted.
 
 ```graphql
 query {
@@ -60,7 +60,7 @@ Note that some columns like `created_at` have default values, even though you di
 
 ## Subscription {#subscription}
 
-Let's run a subscription query over `users` table to watch for changes to the table.
+Let's run a [subscription](https://hasura.io/docs/latest/subscriptions/index/) query over `users` table to watch for changes to the table.
 
 ```graphql
 subscription {

--- a/tutorials/backend/hasura-auth-slack/tutorial-site/content/data-modeling/4-try-queries.md
+++ b/tutorials/backend/hasura-auth-slack/tutorial-site/content/data-modeling/4-try-queries.md
@@ -10,7 +10,7 @@ Let's go ahead and start exploring the GraphQL APIs for `users` table.
 
 ## Mutation {#mutation}
 
-Head over to Console -> GRAPHIQL tab and insert a user using [GraphQL Mutations](https://hasura.io/docs/latest/mutations/index/).
+Head over to Console -> GRAPHIQL tab and insert a user using [GraphQL Mutations](https://hasura.io/learn/graphql/intro-graphql/graphql-mutations/).
 
 ```graphql
 mutation {

--- a/tutorials/backend/hasura-auth-slack/tutorial-site/content/thinking-in-roles.md
+++ b/tutorials/backend/hasura-auth-slack/tutorial-site/content/thinking-in-roles.md
@@ -6,7 +6,7 @@ metaDescription: "Role based access control in Hasura lets the server control wh
 
 In this part of the tutorial, we will look at how to model roles for the app.
 
-Role based access control lets the server control what data is accessed by each user on the client. This can enforce granular restrictions on data access.
+[Role based access control](https://hasura.io/docs/latest/auth/authorization/index/) lets the server control what data is accessed by each user on the client. This can enforce granular restrictions on data access.
 
 Let's think about the different set of roles applicable to users of Slack.
 

--- a/tutorials/backend/hasura-authentication/tutorial-site/content/authentication-modes.md
+++ b/tutorials/backend/hasura-authentication/tutorial-site/content/authentication-modes.md
@@ -13,7 +13,7 @@ The key part to understand is that, Authentication is handled outside of Hasura.
 
 ## JWT Mode {#jwt-mode}
 
-You can configure GraphQL Engine to use the JWT authorization mode to authorize all incoming requests. The auth server is expected to return a valid JWT token, which are decoded and verified by the GraphQL engine, to authorize and get metadata about the request.
+You can configure GraphQL Engine to use the [JWT authorization mode](https://hasura.io/docs/latest/auth/authentication/jwt/) to authorize all incoming requests. The auth server is expected to return a valid JWT token, which are decoded and verified by the GraphQL engine, to authorize and get metadata about the request.
 
 A typical architecture with Auth server issuing JWT looks like the one below:
 
@@ -23,7 +23,7 @@ The Auth Server issues JWT tokens with relevant `x-hasura-*` claims to the app w
 
 ## Webhook Mode {#webhook-mode}
 
-You can also configure GraphQL Engine to use the Webhook mode. Your auth server exposes a webhook that is used to authenticate all incoming requests to the Hasura GraphQL engine server and to get metadata about the request to evaluate access control rules.
+You can also configure GraphQL Engine to use the [Webhook mode](https://hasura.io/docs/latest/auth/authentication/webhook/). Your auth server exposes a webhook that is used to authenticate all incoming requests to the Hasura GraphQL engine server and to get metadata about the request to evaluate access control rules.
 
 The architecture with webhook looks like the one below:
 
@@ -31,4 +31,4 @@ The architecture with webhook looks like the one below:
 
 ### Unauthenticated Mode {#unauthenticated-mode}
 
-Sometimes you would like to allow access to data without a user being logged in. This is useful for public feed which is open to all users. Although our Slack app doesn't have this as a use case, it is good to know when this could be used.
+Sometimes you would like to allow [access to data without a user being logged in](https://hasura.io/docs/latest/auth/authentication/unauthenticated-access/). This is useful for public feed which is open to all users. Although our Slack app doesn't have this as a use case, it is good to know when this could be used.

--- a/tutorials/backend/hasura-authentication/tutorial-site/content/introduction.md
+++ b/tutorials/backend/hasura-authentication/tutorial-site/content/introduction.md
@@ -4,7 +4,7 @@ metaTitle: "Course Introduction | Hasura Authentication Tutorial"
 metaDescription: "A powerful and concise tutorial that will introduce you to setting up an Authentication service in Hasura with a walkthrough of JWT configuration"
 ---
 
-This course is a super fast introduction to model and think about Authentication with Hasura GraphQL.
+This course is a super fast introduction to model and think about [Authentication](https://hasura.io/docs/latest/auth/authentication/index/) with Hasura GraphQL.
 
 ## Pre-requisites {#prerequisites}
 


### PR DESCRIPTION
Covering [DOCS-191](https://hasurahq.atlassian.net/browse/DOCS-191?atlOrigin=eyJpIjoiYzBhNTBjMDU3YjUxNDUyNTg3NDRhZDUwNTM3M2E4MzMiLCJwIjoiaiJ9), this PR is the second in a series that will address docs backlinking in Learn tutorials. 

**NB: I made a deliberate effort to do the additions sparingly. The flow of these tutorials is critical, and any links that move a user away while going step-by-step distract from the tutorial's goal. As such, any docs additions are strategic and included only where a user may need some more context as they're introduced to a concept for the first time.**