### PR TITLE
docs: add backlinks to Hasura Advanced tutorial

### DIFF
--- a/tutorials/backend/hasura-advanced/tutorial-site/content/migrations-metadata.md
+++ b/tutorials/backend/hasura-advanced/tutorial-site/content/migrations-metadata.md
@@ -4,7 +4,7 @@ metaTitle: "Migrations and Metadata | Hasura GraphQL Advanced Tutorial"
 metaDescription: "In this section, we will look at how to manage database migrations and Hasura metadata in a local dev environment setup and learn about database schema and metadata config"
 ---
 
-In this section, we will look at how to manage database migrations and Hasura metadata in a local dev environment setup.
+In this section, we will look at how to manage [database migrations and Hasura metadata](https://hasura.io/docs/latest/migrations-metadata-seeds/index/) in a local dev environment setup.
 
 Hasura needs two components to (re)create a GraphQL API.
 

--- a/tutorials/backend/hasura-advanced/tutorial-site/content/migrations-metadata/2-migration-files.md
+++ b/tutorials/backend/hasura-advanced/tutorial-site/content/migrations-metadata/2-migration-files.md
@@ -4,7 +4,7 @@ metaTitle: "Managing migration files | Hasura GraphQL Advanced Tutorial"
 metaDescription: "Hasura comes with a built-in migration system to manage the database schema. Managing the database schema to perform incremental, reversible updates that are version controlled is a critical component for apps running in production."
 ---
 
-Managing the database schema to perform incremental, reversible updates that are version controlled is a critical component for apps running in production. Hasura comes with a built-in migration system to manage the database schema.
+Managing the database schema to perform incremental, reversible updates that are version controlled is a critical component for apps running in production. Hasura comes with a [built-in migration system](https://hasura.io/docs/latest/migrations-metadata-seeds/manage-migrations/) to manage the database schema.
 
 More importantly, migration files are generated automatically by the Console UI, when served through the CLI. This makes it easy to make changes to the schema like creating tables, columns, functions, views by simply using the UI. Read more about the [architecture of how Hasura built the UI to autogenerate database migrations](https://hasura.io/blog/building-a-ui-for-postgresql-database-migrations/).
 

--- a/tutorials/backend/hasura-advanced/tutorial-site/content/migrations-metadata/3-metadata.md
+++ b/tutorials/backend/hasura-advanced/tutorial-site/content/migrations-metadata/3-metadata.md
@@ -4,7 +4,7 @@ metaTitle: "Managing Metadata | Hasura GraphQL Advanced Tutorial"
 metaDescription: "In addition to managing migration files, Hasura has metadata that needs to be maintained and version controlled too."
 ---
 
-In addition to managing migration files, Hasura has metadata that needs to be maintained and version controlled too. Migration files are created primarily for actions performed towards updating the `database schema`. On the other hand, metadata files are updated whenever an action is performed on the console, like tracking tables/views/functions, creating relationships, configuring permissions, creating event triggers and remote schemas, etc. can be exported as a JSON/yaml metadata file which can be version controlled.
+In addition to managing migration files, Hasura has [metadata](https://hasura.io/docs/latest/migrations-metadata-seeds/manage-metadata/) that needs to be maintained and version controlled too. Migration files are created primarily for actions performed towards updating the `database schema`. On the other hand, metadata files are updated whenever an action is performed on the console, like tracking tables/views/functions, creating relationships, configuring permissions, creating event triggers and remote schemas, etc. can be exported as a JSON/yaml metadata file which can be version controlled.
 
 The metadata file can be later imported to another Hasura instance to get the same configuration (provided the database schema exists). You can also manually edit the metadata file to add more objects to it and then use it to update the instance.
 

--- a/tutorials/backend/hasura-advanced/tutorial-site/content/reliability/1-health-check.md
+++ b/tutorials/backend/hasura-advanced/tutorial-site/content/reliability/1-health-check.md
@@ -4,7 +4,7 @@ metaTitle: "Health Check | Hasura GraphQL Advanced Tutorial"
 metaDescription: "Hasura gives a health check endpoint to monitor the status of the GraphQL API. This is available under `/healthz` endpoint for all Hasura projects (including the OSS GraphQL Engine)."
 ---
 
-Hasura gives a health check endpoint to monitor the status of the GraphQL API. This is available under `/healthz` endpoint for all Hasura projects (including the OSS GraphQL Engine).
+Hasura gives a [health check endpoint](https://hasura.io/docs/latest/deployment/health-checks/healthz-check/) to monitor the status of the GraphQL API. This is available under `/healthz` endpoint for all Hasura projects (including the OSS GraphQL Engine).
 
 Make a `GET` request to the `/healthz` endpoint to fetch the status.
 

--- a/tutorials/backend/hasura-advanced/tutorial-site/content/reliability/2-observability.md
+++ b/tutorials/backend/hasura-advanced/tutorial-site/content/reliability/2-observability.md
@@ -4,7 +4,7 @@ metaTitle: "Observability | Hasura GraphQL Advanced Tutorial"
 metaDescription: "Observability means you can answer any questions about what’s happening on the inside of the system just by observing metrics from outside of the system"
 ---
 
-Observability means you can answer any questions about what’s happening on the inside of the system just by observing metrics from outside of the system.
+[Observability](https://hasura.io/docs/latest/observability/index/) means you can answer any questions about what’s happening on the inside of the system just by observing metrics from outside of the system.
 
 In a GraphQL application, these are the important metrics and context to capture:
 

--- a/tutorials/backend/hasura-advanced/tutorial-site/content/reliability/3-regression-testing.md
+++ b/tutorials/backend/hasura-advanced/tutorial-site/content/reliability/3-regression-testing.md
@@ -4,7 +4,7 @@ metaTitle: "Regression Testing | Hasura GraphQL Advanced Tutorial"
 metaDescription: "Regression tests ensure continued support for operations required by your frontend apps or users"
 ---
 
-Regression tests ensure continued support for operations required by your frontend apps or users i.e. validating changes to the GraphQL schema (schema integrity) against these operations to ensure that there are no breaking changes or regressions in your GraphQL API.
+[Regression tests](https://hasura.io/docs/latest/deployment/hasura-cloud/regression-tests/) ensure continued support for operations required by your frontend apps or users i.e. validating changes to the GraphQL schema (schema integrity) against these operations to ensure that there are no breaking changes or regressions in your GraphQL API.
 
 ![Regression Testing with Hasura](https://hasura.io/blog/content/images/2020/02/regression-testing-diagram-2.png)
 

--- a/tutorials/backend/hasura-advanced/tutorial-site/content/security/3-allow-list.md
+++ b/tutorials/backend/hasura-advanced/tutorial-site/content/security/3-allow-list.md
@@ -4,7 +4,7 @@ metaTitle: "Allow Lists | Hasura GraphQL Advanced Tutorial"
 metaDescription: "Allowlist can be configured to safely allow a limited number of GraphQL operations (queries/mutations/subscriptions) for your project."
 ---
 
-Allowlist can be configured to safely allow a limited number of GraphQL operations (queries/mutations/subscriptions) for your project.
+[Allowlist](https://hasura.io/docs/latest/security/allow-list/) can be configured to safely allow a limited number of GraphQL operations (queries/mutations/subscriptions) for your project.
 
 Operations to Allowlist can be added
 

--- a/tutorials/backend/hasura-advanced/tutorial-site/content/security/4-rate-limit.md
+++ b/tutorials/backend/hasura-advanced/tutorial-site/content/security/4-rate-limit.md
@@ -4,7 +4,7 @@ metaTitle: "Rate Limiting | Hasura GraphQL Advanced Tutorial"
 metaDescription: "Rate Limiting ensures that API performance issues caused by malicious or poorly implemented queries can be restricted."
 ---
 
-API performance issues are typically caused by malicious or poorly implemented queries. In the case of malicious queries, we can restrict in a way by configuring allow lists as we did in the previous step. But sometimes, you might want to configure restrictions for API access.
+API performance issues are typically caused by malicious or poorly implemented queries. In the case of malicious queries, we can restrict in a way by configuring allow lists as we did in the previous step. But sometimes, you might want to (configure restrictions for API access)[https://hasura.io/docs/latest/security/api-limits/#introduction].
 
 This could be implemented by
 


### PR DESCRIPTION
Covering [DOCS-191](https://hasurahq.atlassian.net/browse/DOCS-191?atlOrigin=eyJpIjoiYzBhNTBjMDU3YjUxNDUyNTg3NDRhZDUwNTM3M2E4MzMiLCJwIjoiaiJ9), this PR is the third in a series that will address docs backlinking in Learn tutorials. 

**NB: I made a deliberate effort to do the additions sparingly. The flow of these tutorials is critical, and any links that move a user away while going step-by-step distract from the tutorial's goal. As such, any docs additions are strategic and included only where a user may need some more context as they're introduced to a concept for the first time.**