### PR TITLE
Fix link on rate-limit page

### DIFF
--- a/tutorials/backend/hasura-advanced/tutorial-site/content/security/4-rate-limit.md
+++ b/tutorials/backend/hasura-advanced/tutorial-site/content/security/4-rate-limit.md
@@ -4,7 +4,7 @@ metaTitle: "Rate Limiting | Hasura GraphQL Advanced Tutorial"
 metaDescription: "Rate Limiting ensures that API performance issues caused by malicious or poorly implemented queries can be restricted."
 ---
 
-Malicious or poorly implemented queries typically cause API performance issues. In the case of malicious queries, we can restrict by configuring allow lists as we did in the previous step. But sometimes, you can (configure restrictions for API access)[https://hasura.io/docs/latest/security/api-limits/#introduction].
+Malicious or poorly implemented queries typically cause API performance issues. In the case of malicious queries, we can restrict by configuring allow lists as we did in the previous step. But sometimes, you can [configure restrictions for API access](https://hasura.io/docs/latest/security/api-limits/#introduction).
 
 It could be implemented as follows:
 - Rate of API requests - Rate limits


### PR DESCRIPTION
### Description
Markdown link notation was wrong.

### Related Issues
N/A

### Solution and Design
Use proper markdown link notation.

### Steps to test and verify
Just preview this markdown file.

### Limitations, known bugs & workarounds
N/A
