### PR TITLE
Add missing step to nextjs-auth.md

### DIFF
--- a/tutorials/backend/hasura-authentication/tutorial-site/content/integrations/nextjs-auth.md
+++ b/tutorials/backend/hasura-authentication/tutorial-site/content/integrations/nextjs-auth.md
@@ -87,6 +87,9 @@ Configure the `user` role to deny all permissions except selecting where id \_eq
 
 ![Hasura Permissions](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/auth0/hasura-permissions.png)
 
+Finally, also add the `accounts.userId -> users.id` relationship on the "Relationships" tab of the users table. 
+This ensure that the adapter library has access to the necessary `accounts` field in the `GetUsers` query.
+
 ### Create Next.js App
 
 #### Setup Boilerplate


### PR DESCRIPTION
Adds missing step to create the object relationship `accounts.userId -> users.id`.

### Description
While following the guide I was running into this issue:
```
https://next-auth.js.org/errors#adapter_error_getuserbyaccount field 'accounts' not found in type: 'users_bool_exp': {"response":{"errors":[{"extensions":{"code":"validation-failed","path":"$.selectionSet.users.args.where.accounts"},"message":"field 'accounts' not found in type: 'users_bool_exp'"}]
```

It was solved by adding the object relationship as mentioned.

### Steps to test and verify
Use the guide with current versions and try to login. It will throw the above error. 

After adding the object relationship it will work, as it adds the necessary `accounts` field to the `GetUsers` query.


