### PR TITLE
Update references to @apollo/client for Svelte

### DIFF
--- a/tutorials/frontend/svelte-apollo/app-final/src/apollo.js
+++ b/tutorials/frontend/svelte-apollo/app-final/src/apollo.js
@@ -1,4 +1,4 @@
-import { split, HttpLink, InMemoryCache, ApolloClient } from "@apollo/client";
+import { split, HttpLink, InMemoryCache, ApolloClient } from "@apollo/client/core";
 import { getMainDefinition } from "@apollo/client/utilities";
 import { WebSocketLink } from "@apollo/client/link/ws";
 

--- a/tutorials/frontend/svelte-apollo/app-final/src/components/OnlineUsers/OnlineUsersWrapper.svelte
+++ b/tutorials/frontend/svelte-apollo/app-final/src/components/OnlineUsers/OnlineUsersWrapper.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount, onDestroy } from "svelte";
   import OnlineUser from "./OnlineUser.svelte";
-  import { gql } from "@apollo/client";
+  import { gql } from "@apollo/client/core";
   import { subscribe, mutation } from "svelte-apollo";
 
   const onlineUsers = subscribe(gql`

--- a/tutorials/frontend/svelte-apollo/app-final/src/components/Todo/TodoInput.svelte
+++ b/tutorials/frontend/svelte-apollo/app-final/src/components/Todo/TodoInput.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { gql } from "@apollo/client";
+  import { gql } from "@apollo/client/core";
   import { mutation } from "svelte-apollo";
   import { GET_MY_TODOS } from "./queries";
 

--- a/tutorials/frontend/svelte-apollo/app-final/src/components/Todo/TodoItem.svelte
+++ b/tutorials/frontend/svelte-apollo/app-final/src/components/Todo/TodoItem.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { gql } from "@apollo/client";
+  import { gql } from "@apollo/client/core";
   import { mutation } from "svelte-apollo";
   import { GET_MY_TODOS } from "./queries";
   export let todo;

--- a/tutorials/frontend/svelte-apollo/app-final/src/components/Todo/TodoPrivateList.svelte
+++ b/tutorials/frontend/svelte-apollo/app-final/src/components/Todo/TodoPrivateList.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { gql } from "@apollo/client";
+  import { gql } from "@apollo/client/core";
   import { query, mutation } from "svelte-apollo";
   import TodoFilters from "./TodoFilters.svelte";
   import TodoItem from "./TodoItem.svelte";

--- a/tutorials/frontend/svelte-apollo/app-final/src/components/Todo/TodoPublicList.svelte
+++ b/tutorials/frontend/svelte-apollo/app-final/src/components/Todo/TodoPublicList.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { gql } from "@apollo/client";
+  import { gql } from "@apollo/client/core";
   import { onMount } from "svelte";
   import { query, mutation, getClient } from "svelte-apollo";
   import TaskItem from "./TaskItem.svelte";

--- a/tutorials/frontend/svelte-apollo/app-final/src/components/Todo/TodoPublicListSubscription.svelte
+++ b/tutorials/frontend/svelte-apollo/app-final/src/components/Todo/TodoPublicListSubscription.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { gql } from "@apollo/client";
+  import { gql } from "@apollo/client/core";
   import { subscribe } from "svelte-apollo";
   import TodoPublicList from "./TodoPublicList.svelte";
 

--- a/tutorials/frontend/svelte-apollo/app-final/src/components/Todo/queries.js
+++ b/tutorials/frontend/svelte-apollo/app-final/src/components/Todo/queries.js
@@ -1,4 +1,4 @@
-import { gql } from "@apollo/client";
+import { gql } from "@apollo/client/core";
 
 export const GET_MY_TODOS = gql`
   query getMyTodos {

--- a/tutorials/frontend/svelte-apollo/tutorial-site/content/mutations-variables/2-query-variables.md
+++ b/tutorials/frontend/svelte-apollo/tutorial-site/content/mutations-variables/2-query-variables.md
@@ -18,7 +18,7 @@ Open `src/components/Todo/TodoInput.svelte` and add the following code:
 
 ```javascript
 <script>
-+ import { gql } from "@apollo/client";
++ import { gql } from "@apollo/client/core";
 
 + const ADD_TODO = gql `
 +  mutation ($todo: String!, $isPublic: Boolean!) {

--- a/tutorials/frontend/svelte-apollo/tutorial-site/content/optimistic-update-mutations/2-mutation-cache.md
+++ b/tutorials/frontend/svelte-apollo/tutorial-site/content/optimistic-update-mutations/2-mutation-cache.md
@@ -9,7 +9,7 @@ import GithubLink from "../../src/GithubLink.js";
 Now let's do the integration part. Open `src/components/Todo/TodoItem.svelte` and add the following code below the other imports:
 
 ```javascript
-+ import { gql } from "@apollo/client";
++ import { gql } from "@apollo/client/core";
 ```
 
 Let's define the graphql mutation to update the completed status of the todo
@@ -17,7 +17,7 @@ Let's define the graphql mutation to update the completed status of the todo
 <GithubLink link="https://github.com/hasura/learn-graphql/blob/master/tutorials/frontend/svelte-apollo/app-final/src/components/Todo/TodoItem.svelte" text="src/components/Todo/TodoItem.svelte" />
 
 ```javascript
-  import { gql } from "@apollo/client";
+  import { gql } from "@apollo/client/core";
 
 +  const TOGGLE_TODO = gql`
 +    mutation toggleTodo ($id: Int!, $isCompleted: Boolean!) {
@@ -35,7 +35,7 @@ Let's define the graphql mutation to update the completed status of the todo
 We need to use `mutation` function from `apollo-svelte` to make the mutate function.
 
 ```javascript
-  import { gql } from "@apollo/client";
+  import { gql } from "@apollo/client/core";
 + import { mutation } from "svelte-apollo";
 
   const TOGGLE_TODO = gql`

--- a/tutorials/frontend/svelte-apollo/tutorial-site/content/queries/2-create-query.md
+++ b/tutorials/frontend/svelte-apollo/tutorial-site/content/queries/2-create-query.md
@@ -48,7 +48,7 @@ The query is now ready, let's integrate it with our svelte code.
 `query` function is being imported from `svelte-apollo`
 
 ```javascript
-import { gql } from "@apollo/client";
+import { gql } from "@apollo/client/core";
 import { query } from "svelte-apollo";
 
 import TodoItem from "./TodoItem";

--- a/tutorials/frontend/svelte-apollo/tutorial-site/content/realtime-feed/1-fetch-public.md
+++ b/tutorials/frontend/svelte-apollo/tutorial-site/content/realtime-feed/1-fetch-public.md
@@ -14,7 +14,7 @@ Open `src/components/Todo/TodoPublicListSubscription.svelte` and add the followi
 
 ```javascript
 <script>
-  import { gql } from "@apollo/client";
+  import { gql } from "@apollo/client/core";
   import { subscribe } from "svelte-apollo";
 
   const NOTIFY_NEW_PUBLIC_TODOS = gql`

--- a/tutorials/frontend/svelte-apollo/tutorial-site/content/subscriptions.md
+++ b/tutorials/frontend/svelte-apollo/tutorial-site/content/subscriptions.md
@@ -30,7 +30,7 @@ Open `src/components/OnlineUsers/OnlineUsersWrapper.svelte` and add the followin
 
 ```javascript
 + import { onMount, onDestroy } from "svelte";
-+ import { gql } from "@apollo/client";
++ import { gql } from "@apollo/client/core";
 + import { subscribe, mutation } from "svelte-apollo";
 ```
 

--- a/tutorials/frontend/svelte-apollo/tutorial-site/content/subscriptions/1-subscription.md
+++ b/tutorials/frontend/svelte-apollo/tutorial-site/content/subscriptions/1-subscription.md
@@ -23,7 +23,7 @@ Open `src/apollo.js` and update the following imports:
 Update the createApolloClient function to integrate WebSocketLink.
 
 ```
-import { split, HttpLink, InMemoryCache, ApolloClient } from "@apollo/client";
+import { split, HttpLink, InMemoryCache, ApolloClient } from "@apollo/client/core";
 import { getMainDefinition } from "@apollo/client/utilities";
 import { WebSocketLink } from "@apollo/client/link/ws";
 

--- a/tutorials/frontend/svelte-apollo/tutorial-site/content/subscriptions/2-create-subscription.md
+++ b/tutorials/frontend/svelte-apollo/tutorial-site/content/subscriptions/2-create-subscription.md
@@ -15,7 +15,7 @@ Open `src/components/OnlineUsers/OnlineUsersWrapper.svelte` and add the followin
 ```
 <script>
   import OnlineUser from "./OnlineUser.svelte";
-+  import { gql } from "@apollo/client";
++  import { gql } from "@apollo/client/core";
 +  import { subscribe, mutation } from "svelte-apollo";
 
 +  const onlineUsers = subscribe(gql`


### PR DESCRIPTION
In newer versions of Apollo or Svelte, importing @apollo/client requires React being installed.
Since this likely doesn't make sense for a Svelte app, I updated the references.
See also https://github.com/apollographql/apollo-client/issues/7318
