### PR TITLE
docs: add skip onboarding query param

### DIFF
--- a/tutorials/backend/hasura-advanced/tutorial-site-es/content/migrations-metadata/4-dev-enviroments.md
+++ b/tutorials/backend/hasura-advanced/tutorial-site-es/content/migrations-metadata/4-dev-enviroments.md
@@ -1,28 +1,37 @@
 ---
 title: "Entornos de desarrollo"
 metaTitle: "Entornos de desarrollo | Tutorial avanzado de Hasura GraphQL"
-metaDescription: "Hasura puede utilizarse en diferentes entornos, desde el desarrollo local hasta los ensayos y la producción, con el uso de migraciones y metadatos."
+metaDescription:
+  "Hasura puede utilizarse en diferentes entornos, desde el desarrollo local hasta los ensayos y la producción, con el
+  uso de migraciones y metadatos."
 ---
 
 ## Desarrollo local {#local-development}
 
-La instancia Hasura ejecutada de forma local en su máquina con docker-compose actúa como configuración del entorno de desarrollo. Hasura CLI puede utilizarse para ayudar a la consola con la gestión automática de las migraciones y los metadatos.
+La instancia Hasura ejecutada de forma local en su máquina con docker-compose actúa como configuración del entorno de
+desarrollo. Hasura CLI puede utilizarse para ayudar a la consola con la gestión automática de las migraciones y los
+metadatos.
 
 ## Entorno de ensayo {#staging-environment}
 
-Ahora vamos a crear un entorno de ensayo y a tratar de replicar el esquema y los metadatos que tenemos en nuestra configuración local de desarrollo.
+Ahora vamos a crear un entorno de ensayo y a tratar de replicar el esquema y los metadatos que tenemos en nuestra
+configuración local de desarrollo.
 
-Vamos a utilizar Hasura Cloud para el entorno de ensayo. [Hasura Cloud](https://hasura.io/cloud/) le ofrece una API de GraphQL escalable, altamente disponible, distribuida a nivel global, totalmente gestionada y segura como servicio.
+Vamos a utilizar Hasura Cloud para el entorno de ensayo. [Hasura Cloud](https://hasura.io/cloud/) le ofrece una API de
+GraphQL escalable, altamente disponible, distribuida a nivel global, totalmente gestionada y segura como servicio.
 
 Haga clic en el siguiente botón para crear un nuevo proyecto en Hasura Cloud:
 
-<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
-Una vez se registre e inicie sesión, debería ver la siguiente pantalla de bienvenida y se creará un nuevo proyecto de Hasura automáticamente para usted:
+Una vez se registre e inicie sesión, debería ver la siguiente pantalla de bienvenida y se creará un nuevo proyecto de
+Hasura automáticamente para usted:
 
 ![Página de bienvenida de Hasura Cloud](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-welcome.png)
 
-Una vez que se inicie el proyecto, puede hacer clic en el botón `Launch Console` en la ventana emergente. Si ya dispone de una cuenta de Hasura Cloud, puede crear un nuevo proyecto haciendo clic en la acción `+ New Project` en la parte superior y luego en `Launch Console`.
+Una vez que se inicie el proyecto, puede hacer clic en el botón `Launch Console` en la ventana emergente. Si ya dispone
+de una cuenta de Hasura Cloud, puede crear un nuevo proyecto haciendo clic en la acción `+ New Project` en la parte
+superior y luego en `Launch Console`.
 
 ## Consola de Hasura {#hasura-console}
 
@@ -30,14 +39,17 @@ Esto abrirá la consola de Hasura para el proyecto. Debería parecerse a esto:
 
 ![Consola de Hasura](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-console.png)
 
-El siguiente paso es conectar la base de datos a Hasura. Para configurarla, podemos hacer uso del nivel de base de datos Postgres gratuito de Heroku. Diríjase a la pestaña `Data` en la consola y haga clic en `Connect Database`.
+El siguiente paso es conectar la base de datos a Hasura. Para configurarla, podemos hacer uso del nivel de base de datos
+Postgres gratuito de Heroku. Diríjase a la pestaña `Data` en la consola y haga clic en `Connect Database`.
 
 Tenemos dos opciones para conectar una base de datos:
 
 - Conectar una base de datos existente
 - Crear la base de datos de Heroku (gratis)
 
-Para iniciar este proceso, vamos a crear una nueva base de datos de Postgres desde cero utilizando Heroku Postgres. Haga clic en la pestaña `Create Heroku Database (Free)`. En esta pestaña, dispondrá ahora de una opción para hacer clic en el botón `Create Database`. Tenga en cuenta que crear una cuenta en Heroku es gratis.
+Para iniciar este proceso, vamos a crear una nueva base de datos de Postgres desde cero utilizando Heroku Postgres. Haga
+clic en la pestaña `Create Heroku Database (Free)`. En esta pestaña, dispondrá ahora de una opción para hacer clic en el
+botón `Create Database`. Tenga en cuenta que crear una cuenta en Heroku es gratis.
 
 ![Cree la base de datos de Heroku](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/create-heroku-database.png)
 
@@ -49,9 +61,11 @@ Después de iniciar sesión en Heroku y hacer clic en `Create Database`, Hasura 
 
 ![Configuración de Heroku de Hasura Cloud](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-heroku-setup.png)
 
-Se necesitarán unos segundos para conectarse a Heroku Postgres e inicializar. Una vez establecida la conexión, se le llevará a la página del Gestor de datos en la Consola, que enumera la base de datos que acabamos de conectar.
+Se necesitarán unos segundos para conectarse a Heroku Postgres e inicializar. Una vez establecida la conexión, se le
+llevará a la página del Gestor de datos en la Consola, que enumera la base de datos que acabamos de conectar.
 
-Ahora, copie la URL del proyecto que se parece a `https://myproject.hasura.app`, (sustituya `myproject` por el nombre de su proyecto Hasura).
+Ahora, copie la URL del proyecto que se parece a `https://myproject.hasura.app`, (sustituya `myproject` por el nombre de
+su proyecto Hasura).
 
 Vuelva al terminal, y al directorio del proyecto Hasura. Ejecute el siguiente comando:
 
@@ -60,15 +74,25 @@ hasura migrate apply --endpoint https://myproject.hasura.app --admin-secret xxxx
 hasura metadata apply --endpoint https://myproject.hasura.app --admin-secret xxxxx
 ```
 
-A continuación, pruebe a refrescar la Consola Hasura en el proyecto Cloud y compruebe si el esquema de la base de datos aparece reflejado. Básicamente, hemos replicado el esquema y los metadatos en una nueva instancia de Hasura y una nueva base de datos Postgres.
+A continuación, pruebe a refrescar la Consola Hasura en el proyecto Cloud y compruebe si el esquema de la base de datos
+aparece reflejado. Básicamente, hemos replicado el esquema y los metadatos en una nueva instancia de Hasura y una nueva
+base de datos Postgres.
 
-A medida que vayamos cambiando el esquema de forma local, podemos seguir aplicando los dos comandos anteriores para aplicar los mismos cambios al entorno de ensayo.
+A medida que vayamos cambiando el esquema de forma local, podemos seguir aplicando los dos comandos anteriores para
+aplicar los mismos cambios al entorno de ensayo.
 
-**Nota**: puede también crear un proyecto en Hasura Cloud para su desarrollo. Todos los pasos necesarios para sincronizar entre desarrollo y ensayo continuarían sin cambios. Normalmente, los controladores de las URL de webhook han de ser expuestos a un punto de conexión público al que pueda acceder Hasura Cloud y, por lo tanto, no pueden ser urls `localhost`. Recomendamos utilizar algo como `ngrok` para exponer al servidor local que se ejecute para Acciones/Esquemas remotos/Eventos a un punto de conexión de acceso público.
+**Nota**: puede también crear un proyecto en Hasura Cloud para su desarrollo. Todos los pasos necesarios para
+sincronizar entre desarrollo y ensayo continuarían sin cambios. Normalmente, los controladores de las URL de webhook han
+de ser expuestos a un punto de conexión público al que pueda acceder Hasura Cloud y, por lo tanto, no pueden ser urls
+`localhost`. Recomendamos utilizar algo como `ngrok` para exponer al servidor local que se ejecute para
+Acciones/Esquemas remotos/Eventos a un punto de conexión de acceso público.
 
 ## Aplastar migraciones {#squashing-migrations}
 
-A medida que vamos cambiando la base de datos, el directorio de migración se llena de «ruido» a causa de todas los archivos creados durante el proceso de iteración del desarrollo. Una vez se ha fijado una característica, es posible que quiera combinarla y «aplastar» todos los archivos de migración relacionados con ella dentro de un único archivo. Puede lograrse utilizando el comando squash de Hasura CLI. Ejecute el siguiente comando:
+A medida que vamos cambiando la base de datos, el directorio de migración se llena de «ruido» a causa de todas los
+archivos creados durante el proceso de iteración del desarrollo. Una vez se ha fijado una característica, es posible que
+quiera combinarla y «aplastar» todos los archivos de migración relacionados con ella dentro de un único archivo. Puede
+lograrse utilizando el comando squash de Hasura CLI. Ejecute el siguiente comando:
 
 ```bash
 hasura migrate squash --name "squashed-migration" --from 123 --database-name default --endpoint https://myproject.hasura.app

--- a/tutorials/backend/hasura-advanced/tutorial-site-ja/content/migrations-metadata/4-dev-enviroments.md
+++ b/tutorials/backend/hasura-advanced/tutorial-site-ja/content/migrations-metadata/4-dev-enviroments.md
@@ -6,69 +6,85 @@ metaDescription: "Hasuraは、移行とメタデータを活用することで�
 
 ## ローカル開発 {#local-development}
 
-docker-composeを使用してマシン上でローカルに実行されるHasuraインスタンスは、開発環境のセットアップによるものです。Hasura CLIは、マイグレーションとメタデータの自動管理のためのコンソールとして使用できます。
+docker-compose を使用してマシン上でローカルに実行される Hasura インスタンスは、開発環境のセットアップによるものです
+。Hasura CLI は、マイグレーションとメタデータの自動管理のためのコンソールとして使用できます。
 
 ## ステージング環境 {#staging-environment}
 
 ここでは、ステージング環境を作成して、ローカル環境セットアップ内のスキーマとメタデータを複製します。
 
-ステージング環境にはHasuraクラウドを使用します。[Hasuraクラウド](https://hasura.io/cloud/) は、拡張性、可用性、安全性が高く、グローバルに展開し、完全な管理を実現するGraphQL APIサービスを提供します。
+ステージング環境には Hasura クラウドを使用します。[Hasura クラウド](https://hasura.io/cloud/) は、拡張性、可用性、安全性
+が高く、グローバルに展開し、完全な管理を実現する GraphQL API サービスを提供します。
 
-以下のボタンをクリックして、Hasuraクラウドで新しいプロジェクトを作成します。
+以下のボタンをクリックして、Hasura クラウドで新しいプロジェクトを作成します。
 
-<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
-登録してサインインすると以下のウェルカム画面が表示されて、新しいHasuraプロジェクトが自動的に作成されます。
+登録してサインインすると以下のウェルカム画面が表示されて、新しい Hasura プロジェクトが自動的に作成されます。
 
 ![Hasuraクラウドのウェルカムページ](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-welcome.png)
 
-プロジェクトの初期化が完了したら、ポップアップ画面の `Launch Console` をクリックします。Hasuraクラウドのアカウントを既にお持ちの場合は、画面上部の `+ New Project` をクリックしてから `Launch Console` をクリックします。そうすれば手動で新しいプロジェクトを作成することができます。
+プロジェクトの初期化が完了したら、ポップアップ画面の `Launch Console` をクリックします。Hasura クラウドのアカウントを既
+にお持ちの場合は、画面上部の `+ New Project` をクリックしてから `Launch Console` をクリックします。そうすれば手動で新し
+いプロジェクトを作成することができます。
 
 ## Hasura コンソール {#hasura-console}
 
-続いてプロジェクトのHasura コンソールを開きます。以下のような画面が表示されます。
+続いてプロジェクトの Hasura コンソールを開きます。以下のような画面が表示されます。
 
 ![Hasura Console](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-console.png)
 
-続いてHasuraをデータベースと接続します。この設定には、HerokuのPostgresデータベース層（無料）を使用できます。Consoleの `Data` タブに移動して、 `Connect Database` をクリックします。
+続いて Hasura をデータベースと接続します。この設定には、Heroku の Postgres データベース層（無料）を使用できます。Console
+の `Data` タブに移動して、 `Connect Database` をクリックします。
 
-データベースに接続するには2つの方法があります。
+データベースに接続するには 2 つの方法があります。
 
 - 既存のデータベースへの接続
-- 新しくHerokuデータベースを作成する（無料）
+- 新しく Heroku データベースを作成する（無料）
 
-ここでは早く先に進めるため、Heroku Postgresを使用して新しいPostgresデータベースを一から作成します。`Create Heroku Database (Free)` タブをクリックすると、 `Create Database` ボタンを選択できるオプションが表示されます。Herokuアカウントの作成は無料です。
+ここでは早く先に進めるため、Heroku Postgres を使用して新しい Postgres データベースを一から作成します
+。`Create Heroku Database (Free)` タブをクリックすると、 `Create Database` ボタンを選択できるオプションが表示されます
+。Heroku アカウントの作成は無料です。
 
 ![Heroku データベースの作成](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/create-heroku-database.png)
 
-Heroku にログイン後、 `Create Database` をクリックすると、Hasuraクラウドは以下を実行します。
+Heroku にログイン後、 `Create Database` をクリックすると、Hasura クラウドは以下を実行します。
 
-- Heroku上にアプリを作成する
-- Postgresアドオンをインストールする
-- Hasuraの設定に使用するデータベースのURLを取得する
+- Heroku 上にアプリを作成する
+- Postgres アドオンをインストールする
+- Hasura の設定に使用するデータベースの URL を取得する
 
 ![HasuraクラウドでのHerokuの設定](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-heroku-setup.png)
 
-Heroku Postgresへの接続と初期化には数秒かかります。Postgresへの接続が完了するとConsoleのData Managerページが表示され、先ほど接続したデータベースの一覧が表示されます。
+Heroku Postgres への接続と初期化には数秒かかります。Postgres への接続が完了すると Console の Data Manager ページが表示さ
+れ、先ほど接続したデータベースの一覧が表示されます。
 
-続いてプロジェクトURLの `https://myproject.hasura.app` をコピーしますが、 `myproject` は、Hasuraのプロジェクト名に変更します。
+続いてプロジェクト URL の `https://myproject.hasura.app` をコピーしますが、 `myproject` は、Hasura のプロジェクト名に変
+更します。
 
-ターミナルからHasuraのプロジェクトディレクトリに移動します。以下のコマンドを実行します。
+ターミナルから Hasura のプロジェクトディレクトリに移動します。以下のコマンドを実行します。
 
 ```bash
 hasura migrate apply --endpoint https://myproject.hasura.app --admin-secret xxxxx --database-name default
 hasura metadata apply --endpoint https://myproject.hasura.app --admin-secret xxxxx
 ```
 
-クラウドプロジェクトのHasura Consoleを更新して、データベーススキーマに変更が反映されているか確認します。ここで行う処理の基本は、スキーマとメタデータを、新しいHasuraインスタンスと新しいPostgresデータベースに複製しています。
+クラウドプロジェクトの Hasura Console を更新して、データベーススキーマに変更が反映されているか確認します。ここで行う処理
+の基本は、スキーマとメタデータを、新しい Hasura インスタンスと新しい Postgres データベースに複製しています。
 
-スキーマをローカルで変更し続けているので、上記の2つのコマンドを実行し続ければステージング環境に随時変更を適用できます。
+スキーマをローカルで変更し続けているので、上記の 2 つのコマンドを実行し続ければステージング環境に随時変更を適用できます
+。
 
-**注** ：Hasuraクラウドでも開発用のプロジェクトの作成が可能です。開発環境とステージング環境を同期させる手順はすべて同じです。通常、webhookのURLハンドラーは、Hasuraクラウドがアクセス可能なパブリックエンドポイントに公開する必要があるため、 `localhost` のURLにはできません。`ngrok` のようなサービスを使用して、Actions/Remote Schemas/Eventsのために稼働しているローカルサーバーを、一般にアクセス可能なエンドポイントで公開することをお勧めします。
+**注** ：Hasura クラウドでも開発用のプロジェクトの作成が可能です。開発環境とステージング環境を同期させる手順はすべて同じ
+です。通常、webhook の URL ハンドラーは、Hasura クラウドがアクセス可能なパブリックエンドポイントに公開する必要があるため
+、 `localhost` の URL にはできません。`ngrok` のようなサービスを使用して、Actions/Remote Schemas/Events のために稼働して
+いるローカルサーバーを、一般にアクセス可能なエンドポイントで公開することをお勧めします。
 
 ## 移行データの高圧縮（Squash） {#squashing-migrations}
 
-データベースの変更が続くと、開発の反復処理でファイルが大量に作成され、移行ディレクトリ内のノイズが増えていきます。機能の修正が完了したら、修正に関連するすべての移行ファイルを高圧縮（Squash）して1つのファイルにまとめたい場合があります。squashは、Hasura CLIのsquashコマンドで実行します。以下のコマンドを実行します。
+データベースの変更が続くと、開発の反復処理でファイルが大量に作成され、移行ディレクトリ内のノイズが増えていきます。機能の
+修正が完了したら、修正に関連するすべての移行ファイルを高圧縮（Squash）して 1 つのファイルにまとめたい場合があります
+。squash は、Hasura CLI の squash コマンドで実行します。以下のコマンドを実行します。
 
 ```bash
 hasura migrate squash --name "squashed-migration" --from 123 --database-name default --endpoint https://myproject.hasura.app

--- a/tutorials/backend/hasura-advanced/tutorial-site-zh/content/migrations-metadata/4-dev-enviroments.md
+++ b/tutorials/backend/hasura-advanced/tutorial-site-zh/content/migrations-metadata/4-dev-enviroments.md
@@ -6,23 +6,26 @@ metaDescription: "使用迁移和元数据，Hasura 可以在不同的环境中�
 
 ## 本地开发{#local-development}
 
-使用 docker-compose 在你的机器上本地运行的 Hasura 实例是开发环境设置。Hasura CLI 可用来为控制台提供自动管理迁移和元数据的服务。
+使用 docker-compose 在你的机器上本地运行的 Hasura 实例是开发环境设置。Hasura CLI 可用来为控制台提供自动管理迁移和元数据
+的服务。
 
 ## 暂存环境{#staging-environment}
 
 现在让我们创建一个暂存环境，并尝试复制我们在本地开发设置中的架构和元数据。
 
-我们将利用 Hasura Cloud 作为暂存环境。[Hasura Cloud](https://hasura.io/cloud/) 提供可扩展、高可用、全球分布、全托管、安全的 GraphQL API 即服务！
+我们将利用 Hasura Cloud 作为暂存环境。[Hasura Cloud](https://hasura.io/cloud/) 提供可扩展、高可用、全球分布、全托管、安
+全的 GraphQL API 即服务！
 
 单击以下按钮，在 Hasura Cloud 上创建一个新项目：
 
-<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
 注册并登录后，应该就会看到以下欢迎界面，而且会自动为你创建一个新的 Hasura 项目：
 
 ![Hasura Cloud 欢迎页面](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-welcome.png)
 
-项目初始化后，您可以单击弹出屏幕上的`Launch Console`按钮。如果你之前已有 Hasura Cloud 帐户，则可以单击顶部的`+ New Project`操作，然后单击`Launch Console`，手动创建一个新项目。
+项目初始化后，您可以单击弹出屏幕上的`Launch Console`按钮。如果你之前已有 Hasura Cloud 帐户，则可以单击顶部
+的`+ New Project`操作，然后单击`Launch Console`，手动创建一个新项目。
 
 ## Hasura 控制台{#hasura-console}
 
@@ -30,14 +33,17 @@ metaDescription: "使用迁移和元数据，Hasura 可以在不同的环境中�
 
 ![Hasura 控制台](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-console.png)
 
-下一步是将数据库连接到 Hasura。我们可以利用 Heroku 的免费 Postgres 数据库层来进行设置。转到控制台上的`Data`选项卡，然后单击`Connect Database`。
+下一步是将数据库连接到 Hasura。我们可以利用 Heroku 的免费 Postgres 数据库层来进行设置。转到控制台上的`Data`选项卡，然后
+单击`Connect Database`。
 
 我们提供两个连接数据库的选项：
 
 - 连接现有数据库
 - 创建 Heroku 数据库（免费）
 
-为快速启动这一过程，我们将借助 Heroku Postgres 从头开始创建一个新的 Postgres 数据库。点击`Create Heroku Database (Free)`选项卡。在这个选项卡中，你现在可以选择单击`Create Database`按钮。请注意，在 Heroku 上创建帐户是免费的。
+为快速启动这一过程，我们将借助 Heroku Postgres 从头开始创建一个新的 Postgres 数据库。点
+击`Create Heroku Database (Free)`选项卡。在这个选项卡中，你现在可以选择单击`Create Database`按钮。请注意，在 Heroku 上创
+建帐户是免费的。
 
 ![创建 Heroku 数据库](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/create-heroku-database.png)
 
@@ -49,9 +55,10 @@ metaDescription: "使用迁移和元数据，Hasura 可以在不同的环境中�
 
 ![Hasura Cloud Heroku 配置](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-heroku-setup.png)
 
-连接到 Heroku Postgres 并进行初始化需要几秒钟的时间。在建立连接后，你将来到控制台上的“数据管理器”页面，其中列有我们刚刚连接的数据库。
+连接到 Heroku Postgres 并进行初始化需要几秒钟的时间。在建立连接后，你将来到控制台上的“数据管理器”页面，其中列有我们刚刚
+连接的数据库。
 
-现在复制看起来像`https://myproject.hasura.app`的项目URL。（用你的 Hasura 项目名称替换`myproject`）。
+现在复制看起来像`https://myproject.hasura.app`的项目 URL。（用你的 Hasura 项目名称替换`myproject`）。
 
 返回终端，进入 Hasura 项目目录。执行以下命令：
 
@@ -60,15 +67,19 @@ hasura migrate apply --endpoint https://myproject.hasura.app --admin-secret xxxx
 hasura metadata apply --endpoint https://myproject.hasura.app --admin-secret xxxxx
 ```
 
-现在请尝试在云项目上刷新 Hasura 控制台，查看数据库架构是否已经反映出来。从本质上讲，我们已经将架构和元数据复制到一个新的 Hasura 实例和新的 Postgres 数据库中。
+现在请尝试在云项目上刷新 Hasura 控制台，查看数据库架构是否已经反映出来。从本质上讲，我们已经将架构和元数据复制到一个新的
+Hasura 实例和新的 Postgres 数据库中。
 
 随着我们不断在本地更改架构，我们可以继续使用上述两个命令来将同样的更改应用于暂存环境。
 
-**注**：您也可以在 Hasura Cloud 上创建一个项目进行开发。所有在开发和暂存环境之间同步所需的步骤将保持不变。通常情况下，webhook URL 处理程序需要在 Hasura Cloud 可以访问的公共端点上公开，因此它们不能是 `localhost`URL。我们建议使用类似`ngrok`的方法，通过可公开访问的端点来公开运行操作/远程架构/事件的本地服务器。
+**注**：您也可以在 Hasura Cloud 上创建一个项目进行开发。所有在开发和暂存环境之间同步所需的步骤将保持不变。通常情况下
+，webhook URL 处理程序需要在 Hasura Cloud 可以访问的公共端点上公开，因此它们不能是 `localhost`URL。我们建议使用类
+似`ngrok`的方法，通过可公开访问的端点来公开运行操作/远程架构/事件的本地服务器。
 
 ## 压缩迁移{#squashing-migrations}
 
-随着我们不断更改数据库，迁移目录会因开发迭代过程中创建的文件过多而变得繁杂。当某项功能稳定以后，您可能希望将与其相关的所有迁移文件合并压缩到一个文件中。这可以使用 Hasura CLI 的 squash 命令来实现。执行以下命令：
+随着我们不断更改数据库，迁移目录会因开发迭代过程中创建的文件过多而变得繁杂。当某项功能稳定以后，您可能希望将与其相关的所
+有迁移文件合并压缩到一个文件中。这可以使用 Hasura CLI 的 squash 命令来实现。执行以下命令：
 
 ```bash
 hasura migrate squash --name "squashed-migration" --from 123 --database-name default --endpoint https://myproject.hasura.app

--- a/tutorials/backend/hasura-advanced/tutorial-site/content/migrations-metadata/4-dev-enviroments.md
+++ b/tutorials/backend/hasura-advanced/tutorial-site/content/migrations-metadata/4-dev-enviroments.md
@@ -1,30 +1,37 @@
 ---
 title: "Dev Environments"
 metaTitle: "Dev Environments | Hasura GraphQL Advanced Tutorial"
-metaDescription: "Hasura can be used in different environments starting from local development, staging, and production with the use of migrations and metadata."
+metaDescription:
+  "Hasura can be used in different environments starting from local development, staging, and production with the use of
+  migrations and metadata."
 ---
 
 ## Local Development {#local-development}
 
-The Hasura instance running locally on your machine with docker-compose is the dev environment setup. You can use the Hasura CLI to serve the console for automatic management of migrations and metadata.
+The Hasura instance running locally on your machine with docker-compose is the dev environment setup. You can use the
+Hasura CLI to serve the console for automatic management of migrations and metadata.
 
 ## Staging Environment {#staging-environment}
 
 Now let's create a staging environment and replicate the schema and metadata we have in our local dev setup.
 
-We are going to make use of Hasura Cloud for the staging environment. [Hasura Cloud](https://hasura.io/cloud/) gives you a scalable, highly available, globally distributed, fully managed, secure GraphQL API as a service!
+We are going to make use of Hasura Cloud for the staging environment. [Hasura Cloud](https://hasura.io/cloud/) gives you
+a scalable, highly available, globally distributed, fully managed, secure GraphQL API as a service!
 
 Click on the following button to create a new project on Hasura Cloud:
 
-<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
 **Note**: It is free to signup, and no credit card is required.
 
-Once you register and sign in, you should see the following welcome screen, and a new Hasura project will be created automatically for you:
+Once you register and sign in, you should see the following welcome screen, and a new Hasura project will be created
+automatically for you:
 
 ![Hasura Cloud Welcome Page](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-welcome.png)
 
-Once the project is initialized, you can click the `Launch Console` button on the pop-up screen. If you already have a Hasura Cloud account, you can manually create a new project by clicking on the `+ New Project` action at the top, followed by `Launch Console`.
+Once the project is initialized, you can click the `Launch Console` button on the pop-up screen. If you already have a
+Hasura Cloud account, you can manually create a new project by clicking on the `+ New Project` action at the top,
+followed by `Launch Console`.
 
 ## Hasura Console {#hasura-console}
 
@@ -32,25 +39,32 @@ This will open up Hasura Console for your project. It should look something like
 
 ![Hasura Console](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-advanced/hasura-console-updated.png)
 
-The next step is to connect the database to Hasura. We can use Neon's free Postgres database tier to set this up. Head to the `Data` tab on the Console and click on `Connect Database`.
+The next step is to connect the database to Hasura. We can use Neon's free Postgres database tier to set this up. Head
+to the `Data` tab on the Console and click on `Connect Database`.
 
 We have two options to connect a database:
+
 - Connect an existing database
 - Create a new database (free)
 
-We'll start by creating a new Postgres DB from scratch using Neon Postgres. Click on the `Create New Database (Free)` tab. In this tab, you can click on the `Connect Neon Database` button. Note that Neon gives you 3 free Postgres database instances.
+We'll start by creating a new Postgres DB from scratch using Neon Postgres. Click on the `Create New Database (Free)`
+tab. In this tab, you can click on the `Connect Neon Database` button. Note that Neon gives you 3 free Postgres database
+instances.
 
 ![Create Neon Database](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-advanced/create-neon-database.png)
 
 After logging in to Neon and clicking on `Create Neon Database`, Hasura Cloud will perform the following for you:
+
 - Create a Postgres database on Neon
 - Fetch the database URL that you can use to configure Hasura
 
-It will take a few seconds to connect to Neon Postgres and initialize the database. Once the connection is ready, you will be taken to the Data Manager page on the Console, listing the database we just connected.
+It will take a few seconds to connect to Neon Postgres and initialize the database. Once the connection is ready, you
+will be taken to the Data Manager page on the Console, listing the database we just connected.
 
 ![Neon database created](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-advanced/neon-database-created.png)
 
-Now copy the project URL that looks like `https://myproject.hasura.app`. (replace `myproject` with your Hasura project name).
+Now copy the project URL that looks like `https://myproject.hasura.app`. (replace `myproject` with your Hasura project
+name).
 
 Head back to the terminal and navigate to the Hasura project directory. Execute the following command:
 
@@ -59,15 +73,22 @@ hasura migrate apply --endpoint https://myproject.hasura.app --admin-secret xxxx
 hasura metadata apply --endpoint https://myproject.hasura.app --admin-secret xxxxx
 ```
 
-Try refreshing the Hasura Console on the Cloud project and see if the database schema reflects there. We have replicated the schema and metadata onto a new Hasura instance and Postgres database.
+Try refreshing the Hasura Console on the Cloud project and see if the database schema reflects there. We have replicated
+the schema and metadata onto a new Hasura instance and Postgres database.
 
-As we keep changing the schema locally, we can keep applying the above two commands to apply the same changes to the staging environment.
+As we keep changing the schema locally, we can keep applying the above two commands to apply the same changes to the
+staging environment.
 
-**Note**: You can also create a project on Hasura Cloud for development. All the steps required to sync between dev and staging would remain the same. Typically, the webhook URL handlers need to be exposed to a public endpoint that Hasura Cloud can access; hence, they cannot be `localhost` URLs. We recommend using something like `ngrok` to expose a local server running for Actions/Remote Schemas/Events to a publicly accessible endpoint.
+**Note**: You can also create a project on Hasura Cloud for development. All the steps required to sync between dev and
+staging would remain the same. Typically, the webhook URL handlers need to be exposed to a public endpoint that Hasura
+Cloud can access; hence, they cannot be `localhost` URLs. We recommend using something like `ngrok` to expose a local
+server running for Actions/Remote Schemas/Events to a publicly accessible endpoint.
 
 ## Squashing Migrations {#squashing-migrations}
 
-As we keep changing the database, the migration directory gets noisy, with too many files created in the dev iteration process. Once a feature is fixed, combine and squash all the related migration files into a single file. This can be achieved using the squash command of the Hasura CLI. Execute the following command:
+As we keep changing the database, the migration directory gets noisy, with too many files created in the dev iteration
+process. Once a feature is fixed, combine and squash all the related migration files into a single file. This can be
+achieved using the squash command of the Hasura CLI. Execute the following command:
 
 ```bash
 hasura migrate squash --name "squashed-migration" --from 123 --database-name default --endpoint https://myproject.hasura.app

--- a/tutorials/backend/hasura-auth-slack/tutorial-site-es/content/setup.md
+++ b/tutorials/backend/hasura-auth-slack/tutorial-site-es/content/setup.md
@@ -1,26 +1,33 @@
 ---
 title: "Despliegue de Hasura"
 metaTitle: "Despliegue de Hasura en Hasura Cloud | Tutorial de Slack de autenticación de Hasura"
-metaDescription: "Este tutorial cubre cómo implementar el motor de GraphQL de Hasura en Hasura Cloud utilizando el despliegue de un solo clic y acceder a la Consola de Hasura"
+metaDescription:
+  "Este tutorial cubre cómo implementar el motor de GraphQL de Hasura en Hasura Cloud utilizando el despliegue de un
+  solo clic y acceder a la Consola de Hasura"
 ---
 
 Empecemos por desplegar Hasura.
 
 ## Despliegue de un clic en Hasura Cloud {#one-click}
 
-La manera más rápida de probar Hasura es a través de Hasura Cloud. ¡[Hasura Cloud](https://hasura.io/cloud/) le ofrece una API de GraphQL escalable, altamente disponible, distribuida mundialmente, totalmente gestionada y segura como servicio!
+La manera más rápida de probar Hasura es a través de Hasura Cloud. ¡[Hasura Cloud](https://hasura.io/cloud/) le ofrece
+una API de GraphQL escalable, altamente disponible, distribuida mundialmente, totalmente gestionada y segura como
+servicio!
 
 Haga clic en el siguiente botón para crear un nuevo proyecto en Hasura Cloud:
 
-<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
 **Nota**: inscribirse es gratis y no se requiere tarjeta de crédito.
 
-Una vez que se registre e inicie sesión, debería ver la siguiente pantalla de bienvenida y se creará automáticamente un nuevo proyecto de Hasura para usted:
+Una vez que se registre e inicie sesión, debería ver la siguiente pantalla de bienvenida y se creará automáticamente un
+nuevo proyecto de Hasura para usted:
 
 ![Página de bienvenida de Hasura Cloud](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-welcome.png)
 
-Una vez que se inicie el proyecto, puede hacer clic en el botón `Launch Console` en la ventana emergente. Si ya tenía una cuenta de Hasura Cloud, puede crear un nuevo proyecto mediante un clic en la acción `+ New Project` en la parte superior y luego en `Launch Console`.
+Una vez que se inicie el proyecto, puede hacer clic en el botón `Launch Console` en la ventana emergente. Si ya tenía
+una cuenta de Hasura Cloud, puede crear un nuevo proyecto mediante un clic en la acción `+ New Project` en la parte
+superior y luego en `Launch Console`.
 
 ## Consola de Hasura {#hasura-console}
 
@@ -28,14 +35,18 @@ Esto abrirá la consola de Hasura para el proyecto. Debería verse algo así:
 
 ![Consola de Hasura](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-console.png)
 
-El siguiente paso es conectar la base de datos a Hasura. Podemos hacer uso del nivel de la [base de datos de Postgres](https://hasura.io/learn/database/postgresql/what-is-postgresql/) gratuita de Heroku para configurar esto. Diríjase a la pestaña `Data` en la consola y haga clic en `Connect Database`.
+El siguiente paso es conectar la base de datos a Hasura. Podemos hacer uso del nivel de la
+[base de datos de Postgres](https://hasura.io/learn/database/postgresql/what-is-postgresql/) gratuita de Heroku para
+configurar esto. Diríjase a la pestaña `Data` en la consola y haga clic en `Connect Database`.
 
 Tenemos dos opciones para conectar una base de datos:
 
 - Conecte una base de datos existente
 - Cree la base de datos de Heroku (gratis)
 
-Para iniciar este proceso, vamos a crear una nueva base de datos de Postgres desde cero utilizando Heroku Postgres. Haga clic en la pestaña `Create Heroku Database (Free)`. En esta pestaña, ahora tiene una opción para hacer clic en el botón `Create Database`. Tenga en cuenta que crear una cuenta en Heroku es gratis.
+Para iniciar este proceso, vamos a crear una nueva base de datos de Postgres desde cero utilizando Heroku Postgres. Haga
+clic en la pestaña `Create Heroku Database (Free)`. En esta pestaña, ahora tiene una opción para hacer clic en el botón
+`Create Database`. Tenga en cuenta que crear una cuenta en Heroku es gratis.
 
 ![Cree la base de datos de Heroku](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/create-heroku-database.png)
 
@@ -47,10 +58,12 @@ Después de iniciar sesión en Heroku y hacer clic en `Create Database`, Hasura 
 
 ![Configuración de Heroku de Hasura Cloud](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-heroku-setup.png)
 
-Se necesitarán unos segundos para conectarse a Heroku Postgres e iniciar. Una vez que se establezca la conexión, se le llevará a la página del gestor de datos en la consola, que enumera la base de datos que acabamos de conectar.
+Se necesitarán unos segundos para conectarse a Heroku Postgres e iniciar. Una vez que se establezca la conexión, se le
+llevará a la página del gestor de datos en la consola, que enumera la base de datos que acabamos de conectar.
 
 También puede gestionar el proyecto desde el panel de control de Hasura Cloud.
 
 ![Página del proyecto de Hasura Cloud](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-project-page.png)
 
-¡Genial! ¡Ahora ha desplegado Hasura, conectado una base de datos y tiene la consola de administrador lista para empezar!
+¡Genial! ¡Ahora ha desplegado Hasura, conectado una base de datos y tiene la consola de administrador lista para
+empezar!

--- a/tutorials/backend/hasura-auth-slack/tutorial-site-ja/content/setup.md
+++ b/tutorials/backend/hasura-auth-slack/tutorial-site-ja/content/setup.md
@@ -1,56 +1,66 @@
 ---
 title: "Hasuraをデプロイする"
 metaTitle: "HasuraクラウドにHasuraをデプロイする | Hasura Auth Slackチュートリアル"
-metaDescription: "このチュートリアルでは、ワンクリックデプロイを使ってHasura GraphQL Engineをデプロイする方法を学び、Hasuraコンソールにアクセスする方法を学びます。"
+metaDescription:
+  "このチュートリアルでは、ワンクリックデプロイを使ってHasura GraphQL
+  Engineをデプロイする方法を学び、Hasuraコンソールにアクセスする方法を学びます。"
 ---
 
-Hasuraをデプロイしてみましょう。
+Hasura をデプロイしてみましょう。
 
-## Hasuraクラウドでのワンクリックデプロイ {#one-click}
+## Hasura クラウドでのワンクリックデプロイ {#one-click}
 
-Hasuraを試す最も早い方法はHasuraクラウドを使うことです。[ Hasuraクラウド ](https://hasura.io/cloud/) は、拡張性、可用性、安全性が高く、グローバルに展開し、完全な管理を実現するGraphQL APIサービスを提供します。
+Hasura を試す最も早い方法は Hasura クラウドを使うことです。[ Hasura クラウド ](https://hasura.io/cloud/) は、拡張性、可
+用性、安全性が高く、グローバルに展開し、完全な管理を実現する GraphQL API サービスを提供します。
 
-以下のボタンをクリックして、Hasuraクラウドで新しいプロジェクトを作成します。
+以下のボタンをクリックして、Hasura クラウドで新しいプロジェクトを作成します。
 
-<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
 **注**：サインアップは無料で、クレジットカードは必要ありません。
 
-登録してサインインすると以下のウェルカム画面が表示されて、新しいHasuraプロジェクトが自動的に作成されます。
+登録してサインインすると以下のウェルカム画面が表示されて、新しい Hasura プロジェクトが自動的に作成されます。
 
 ![ Hasuraクラウドのウェルカムページ ](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-welcome.png)
 
-プロジェクトの初期化が完了したら、ポップアップ画面の `Launch Console` をクリックします。Hasuraクラウドのアカウントを既にお持ちの場合は、画面上部の `+ New Project` をクリックしてから `Launch Console` をクリックします。そうすれば手動で新しいプロジェクトを作成することができます。
+プロジェクトの初期化が完了したら、ポップアップ画面の `Launch Console` をクリックします。Hasura クラウドのアカウントを既
+にお持ちの場合は、画面上部の `+ New Project` をクリックしてから `Launch Console` をクリックします。そうすれば手動で新し
+いプロジェクトを作成することができます。
 
-## Hasura コンソール  {#hasura-console}
+## Hasura コンソール {#hasura-console}
 
-続いてHasura Consoleでプロジェクトを開きます。以下のような画面が表示されます。
+続いて Hasura Console でプロジェクトを開きます。以下のような画面が表示されます。
 
 ![ Hasuraコンソール ](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-console.png)
 
-続いてHasuraをデータベースと接続します。この設定には、Herokuの[Postgresデータベース](https://hasura.io/learn/database/postgresql/what-is-postgresql/)層（無料）を使用できます。コンソールの `Data` タブに移動して、`Connect Database` をクリックします。
+続いて Hasura をデータベースと接続します。この設定には、Heroku
+の[Postgres データベース](https://hasura.io/learn/database/postgresql/what-is-postgresql/)層（無料）を使用できます。コン
+ソールの `Data` タブに移動して、`Connect Database` をクリックします。
 
-データベースに接続するには2つの方法があります。
+データベースに接続するには 2 つの方法があります。
 
 - 既存のデータベースへの接続
-- 新しくHerokuデータベースを作成する（無料）
+- 新しく Heroku データベースを作成する（無料）
 
-ここでは早く先に進めるため、Heroku Postgresを使用して新しいPostgresデータベースを一から作成します。`Create Heroku Database (Free)` タブをクリックすると、 `Create Database` ボタンを選択するオプションが表示されます。Herokuアカウントの作成は無料です。
+ここでは早く先に進めるため、Heroku Postgres を使用して新しい Postgres データベースを一から作成します
+。`Create Heroku Database (Free)` タブをクリックすると、 `Create Database` ボタンを選択するオプションが表示されます
+。Heroku アカウントの作成は無料です。
 
 ![Heroku データベースの作成](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/create-heroku-database.png)
 
-Heroku にログイン後、`Create Database` をクリックすると、Hasuraクラウドは以下を実行します。
+Heroku にログイン後、`Create Database` をクリックすると、Hasura クラウドは以下を実行します。
 
-- Heroku上にアプリを作成する
-- [Postgresアドオンをインストールする](https://hasura.io/learn/database/postgresql/installation/installing-postgresql/)
-- Hasuraの設定に使用するデータベースのURLを取得する
+- Heroku 上にアプリを作成する
+- [Postgres アドオンをインストールする](https://hasura.io/learn/database/postgresql/installation/installing-postgresql/)
+- Hasura の設定に使用するデータベースの URL を取得する
 
 ![ HasuraクラウドでのHerokuの設定 ](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-heroku-setup.png)
 
-Heroku Postgresへの接続と初期化には数秒かかります。Postgresへの接続が完了するとコンソールのData Managerページが表示され、先ほど接続したデータベースの一覧が表示されます。
+Heroku Postgres への接続と初期化には数秒かかります。Postgres への接続が完了するとコンソールの Data Manager ページが表示
+され、先ほど接続したデータベースの一覧が表示されます。
 
-また、Hasuraクラウドダッシュボードからプロジェクトを管理できます。
+また、Hasura クラウドダッシュボードからプロジェクトを管理できます。
 
 ![Hasuraクラウドプロジェクトページ](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-project-page.png)
 
-完璧です。これでHasuraをデプロイして、データベースに接続して、管理コンソールを使えるようになりました！
+完璧です。これで Hasura をデプロイして、データベースに接続して、管理コンソールを使えるようになりました！

--- a/tutorials/backend/hasura-auth-slack/tutorial-site-zh/content/setup.md
+++ b/tutorials/backend/hasura-auth-slack/tutorial-site-zh/content/setup.md
@@ -1,26 +1,32 @@
 ---
 title: "Deploy Hasura"
 metaTitle: "Deploy Hasura to Hasura Cloud | Hasura Auth Slack Tutorial"
-metaDescription: "This tutorial covers how to deploy Hasura GraphQL Engine on Hasura Cloud using one-click deployment and access the Hasura Console"
+metaDescription:
+  "This tutorial covers how to deploy Hasura GraphQL Engine on Hasura Cloud using one-click deployment and access the
+  Hasura Console"
 ---
 
 Let's start by deploying Hasura.
 
 ## One-click deployment on Hasura Cloud {#one-click}
 
-The fastest way to try out Hasura is via Hasura Cloud. [Hasura Cloud](https://hasura.io/cloud/) gives you a scalable, highly available, globally distributed, fully managed, secure GraphQL API as a service!
+The fastest way to try out Hasura is via Hasura Cloud. [Hasura Cloud](https://hasura.io/cloud/) gives you a scalable,
+highly available, globally distributed, fully managed, secure GraphQL API as a service!
 
 Click on the following button to create a new project on Hasura Cloud:
 
-<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
 **Note**: It is free to signup and no credit card is required.
 
-Once you register and sign in, you should see the following welcome screen and a new Hasura project will be created automatically for you:
+Once you register and sign in, you should see the following welcome screen and a new Hasura project will be created
+automatically for you:
 
 ![Hasura Cloud Welcome Page](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-welcome.png)
 
-Once the project is initialised, you can click on `Launch Console` button on the pop up screen. If you already have a Hasura Cloud account before, you can manually create a new project by clicking on the `+ New Project` action at the top, followed by `Launch Console`.
+Once the project is initialised, you can click on `Launch Console` button on the pop up screen. If you already have a
+Hasura Cloud account before, you can manually create a new project by clicking on the `+ New Project` action at the top,
+followed by `Launch Console`.
 
 ## Hasura Console {#hasura-console}
 
@@ -28,14 +34,17 @@ This will open up Hasura Console for your project. It should look something like
 
 ![Hasura Console](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-console-updated.png)
 
-The next step is to connect the database to Hasura. We can make use of Neon's free Postgres database tier to set this up. Head to the `Data` tab on the Console and click on `Connect Database`.
+The next step is to connect the database to Hasura. We can make use of Neon's free Postgres database tier to set this
+up. Head to the `Data` tab on the Console and click on `Connect Database`.
 
 We have two options to connect a database:
 
 - Connect an existing database
 - Create a new database (free)
 
-To quickstart this process, we are going to create a new Postgres DB from scratch using Neon Postgres. Click on `Create New Database (Free)` tab. In this tab, you now have an option to click on the `Connect Neon Database` button. Note that Neon gives you 3 free Posgres database instances.
+To quickstart this process, we are going to create a new Postgres DB from scratch using Neon Postgres. Click on
+`Create New Database (Free)` tab. In this tab, you now have an option to click on the `Connect Neon Database` button.
+Note that Neon gives you 3 free Posgres database instances.
 
 ![Create Neon Database](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/create-neon-database.png)
 
@@ -44,7 +53,8 @@ After logging in to Neon and clicking on `Create Neon Database`, Hasura Cloud wi
 - Create a Postgres database on Neon
 - Fetch database URL that you can use to configure Hasura
 
-It will take a few seconds to connect to Neon Postgres and initialise. Once the connection is established, you will be taken to the Data Manager page on the Console, listing the database that we just connected.
+It will take a few seconds to connect to Neon Postgres and initialise. Once the connection is established, you will be
+taken to the Data Manager page on the Console, listing the database that we just connected.
 
 ![Neon database created](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/neon-database-created.png)
 

--- a/tutorials/backend/hasura-auth-slack/tutorial-site/content/setup.md
+++ b/tutorials/backend/hasura-auth-slack/tutorial-site/content/setup.md
@@ -1,26 +1,32 @@
 ---
 title: "Deploy Hasura"
 metaTitle: "Deploy Hasura to Hasura Cloud | Hasura Auth Slack Tutorial"
-metaDescription: "This tutorial covers how to deploy Hasura GraphQL Engine on Hasura Cloud using one-click deployment and access the Hasura Console"
+metaDescription:
+  "This tutorial covers how to deploy Hasura GraphQL Engine on Hasura Cloud using one-click deployment and access the
+  Hasura Console"
 ---
 
 Let's start by deploying Hasura.
 
 ## One-click deployment on Hasura Cloud {#one-click}
 
-The fastest way to try out Hasura is via Hasura Cloud. [Hasura Cloud](https://hasura.io/cloud/) gives you a scalable, highly available, globally distributed, fully managed, secure GraphQL API as a service!
+The fastest way to try out Hasura is via Hasura Cloud. [Hasura Cloud](https://hasura.io/cloud/) gives you a scalable,
+highly available, globally distributed, fully managed, secure GraphQL API as a service!
 
 Click on the following button to create a new project on Hasura Cloud:
 
-<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
 **Note**: It is free to signup and no credit card is required.
 
-Once you register and sign in, you should see the following welcome screen and a new Hasura project will be created automatically for you:
+Once you register and sign in, you should see the following welcome screen and a new Hasura project will be created
+automatically for you:
 
 ![Hasura Cloud Welcome Page](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-welcome.png)
 
-Once the project is initialised, you can click on `Launch Console` button on the pop up screen. If you already have a Hasura Cloud account before, you can manually create a new project by clicking on the `+ New Project` action at the top, followed by `Launch Console`.
+Once the project is initialised, you can click on `Launch Console` button on the pop up screen. If you already have a
+Hasura Cloud account before, you can manually create a new project by clicking on the `+ New Project` action at the top,
+followed by `Launch Console`.
 
 ## Hasura Console {#hasura-console}
 
@@ -28,14 +34,17 @@ This will open up Hasura Console for your project. It should look something like
 
 ![Hasura Console](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-console-updated.png)
 
-The next step is to connect the database to Hasura. We can make use of Neon's free Postgres database tier to set this up. Head to the `Data` tab on the Console and click on `Connect Database`.
+The next step is to connect the database to Hasura. We can make use of Neon's free Postgres database tier to set this
+up. Head to the `Data` tab on the Console and click on `Connect Database`.
 
 We have two options to connect a database:
 
 - Connect an existing database
 - Create a new database (free)
 
-To quickstart this process, we are going to create a new Postgres DB from scratch using Neon Postgres. Click on `Create New Database (Free)` tab. In this tab, you now have an option to click on the `Connect Neon Database` button. Note that Neon gives you 3 free Posgres database instances.
+To quickstart this process, we are going to create a new Postgres DB from scratch using Neon Postgres. Click on
+`Create New Database (Free)` tab. In this tab, you now have an option to click on the `Connect Neon Database` button.
+Note that Neon gives you 3 free Posgres database instances.
 
 ![Create Neon Database](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/create-neon-database.png)
 
@@ -44,7 +53,8 @@ After logging in to Neon and clicking on `Create Neon Database`, Hasura Cloud wi
 - Create a Postgres database on Neon
 - Fetch database URL that you can use to configure Hasura
 
-It will take a few seconds to connect to Neon Postgres and initialise. Once the connection is established, you will be taken to the Data Manager page on the Console, listing the database that we just connected.
+It will take a few seconds to connect to Neon Postgres and initialise. Once the connection is established, you will be
+taken to the Data Manager page on the Console, listing the database that we just connected.
 
 ![Neon database created](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/neon-database-created.png)
 

--- a/tutorials/backend/hasura-authentication/tutorial-site/content/integrations/auth0.md
+++ b/tutorials/backend/hasura-authentication/tutorial-site/content/integrations/auth0.md
@@ -1,7 +1,9 @@
 ---
 title: "Auth0"
 metaTitle: "Auth0 | Hasura Authentication Tutorial"
-metaDescription: "Auth0 is a service that allows you to integrate authentication and authorization into your applications. Learn how to integrate Auth0 with Hasura using JWT"
+metaDescription:
+  "Auth0 is a service that allows you to integrate authentication and authorization into your applications. Learn how to
+  integrate Auth0 with Hasura using JWT"
 ---
 
 ## What is Auth0
@@ -16,9 +18,11 @@ In this guide, you will learn how to integrate Auth0 with Hasura.
 
 ### Create Auth0 App
 
-To integrate Auth0 with Hasura, you need an Auth0 account. You can manually sign up or log in with other accounts, such as your Google account.
+To integrate Auth0 with Hasura, you need an Auth0 account. You can manually sign up or log in with other accounts, such
+as your Google account.
 
-The first step is to navigate to the [Auth0 dashboard](https://manage.auth0.com/dashboard). Once you log in, you should see the following page:
+The first step is to navigate to the [Auth0 dashboard](https://manage.auth0.com/dashboard). Once you log in, you should
+see the following page:
 
 ![Auth0 Dashboard](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/auth0/auth0-dashboard.png)
 
@@ -29,10 +33,11 @@ After that, go to the `Applications` page and click the `+ Create Application` b
 Once you click the button, a new pop-up appears where you can enter the app name and select your application type.
 
 You can choose:
-* Native
-* Singe Page Web Applications
-* Regular Web Applications
-* Machine to Machine Applications
+
+- Native
+- Singe Page Web Applications
+- Regular Web Applications
+- Machine to Machine Applications
 
 This tutorial uses the "Single Page Web Applications" type as an example.
 
@@ -40,13 +45,16 @@ This tutorial uses the "Single Page Web Applications" type as an example.
 
 Press the "Create" button to create the application!
 
-Now go to the "Settings" tab and scroll down until you see the options "Allowed Callback URLs" and "Allowed Web Origins".
+Now go to the "Settings" tab and scroll down until you see the options "Allowed Callback URLs" and "Allowed Web
+Origins".
 
 Enter the following URLs:
-* **Allowed Callback URLs** - https://localhost:8080/callback
-* **Allowed Web Origins** - https://localhost:8080
 
-**Note**: The "localhost" URLs should reflect the URLs of your app. If your app URL is `http://localhost:6000` or `https://my-app.com`, that’s what you should use.
+- **Allowed Callback URLs** - https://localhost:8080/callback
+- **Allowed Web Origins** - https://localhost:8080
+
+**Note**: The "localhost" URLs should reflect the URLs of your app. If your app URL is `http://localhost:6000` or
+`https://my-app.com`, that’s what you should use.
 
 ### Create Auth0 API
 
@@ -66,7 +74,8 @@ After adding the values, click the `Create` button.
 
 ## Custom JWT Claims
 
-The custom JWT claims are needed because they tell Hasura about the role of the user making the API call. This way, Hasura can enforce the appropriate authorization rules. The rules define what the user is allowed to do.
+The custom JWT claims are needed because they tell Hasura about the role of the user making the API call. This way,
+Hasura can enforce the appropriate authorization rules. The rules define what the user is allowed to do.
 
 Go to the `Rules` page to add custom roles.
 
@@ -96,7 +105,8 @@ Save the new rule by clicking the `Save changes` button.
 
 ## Sync Users Between Auth0 and Hasura
 
-You need to ensure that the users from your database are in sync with Auth0. As a result, you will create another rule to keep the two in sync!
+You need to ensure that the users from your database are in sync with Auth0. As a result, you will create another rule
+to keep the two in sync!
 
 Go to the `Rules` page again > click on `+ Create` > choose the `Empty rule` option.
 
@@ -106,7 +116,7 @@ Now add the following script:
 function (user, context, callback) {
   const userId = user.user_id;
   const userName = user.name;
-  
+
   const admin_secret = "<your-admin-secret>";
   const url = "<your-hasura-app-url>";
   const query = `mutation($userId: String!, $userName: String) {
@@ -146,15 +156,20 @@ The rule will be triggered whenever actions such as signup or login happen!
 
 It's time to integrate the newly created Auth0 application with Hasura.
 
-> It's essential to secure your endpoint with an `admin secret` before going further. Check [this guide](https://hasura.io/docs/latest/graphql/cloud/projects/secure/#adding-an-admin-secret) to learn how to do it.
+> It's essential to secure your endpoint with an `admin secret` before going further. Check
+> [this guide](https://hasura.io/docs/latest/graphql/cloud/projects/secure/#adding-an-admin-secret) to learn how to do
+> it.
 
-After adding the `admin secret`, you need to configure the public keys for Auth0. One way to generate the JWT config is to use the [Hasura JWT configurator](https://hasura.io/jwt-config/).
+After adding the `admin secret`, you need to configure the public keys for Auth0. One way to generate the JWT config is
+to use the [Hasura JWT configurator](https://hasura.io/jwt-config/).
 
 ![Hasura JWT Configurator](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/auth0/hasura-jwt-config.png)
 
-Choose the provider (Auth0) and then enter your "Auth0 Domain Name". After that, press the button "Generate Config" to get your JWT Config.
+Choose the provider (Auth0) and then enter your "Auth0 Domain Name". After that, press the button "Generate Config" to
+get your JWT Config.
 
-You will set the value as an environment variable in your Hasura Project. To do so, go to the [Hasura Dashboard](https://cloud.hasura.io/) and then click the "Gear ⚙️" icon.
+You will set the value as an environment variable in your Hasura Project. To do so, go to the
+[Hasura Dashboard](https://cloud.hasura.io?skip_onboarding=true/) and then click the "Gear ⚙️" icon.
 
 ![Hasura Project Env Vars](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/auth0/hasura-project-env-vars.png)
 
@@ -171,23 +186,27 @@ Congratulations! Auth0 is successfully integrated with your Hasura instance.
 ## Test Database Syncing Rule
 
 Go to your Hasura app dashboard and create a `users` table with the following columns:
-* `id` of type Text (Primary key)
-* `name` of type Text
-* `last_seen` of type Timestamp with default value `now()`
+
+- `id` of type Text (Primary key)
+- `name` of type Text
+- `last_seen` of type Timestamp with default value `now()`
 
 See the image below for reference.
 
 ![Hasura Create Table](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/auth0/hasura-create-table.png)
 
-The next step is to create a `user` role for the app. Users should be able to see only their records, but not the other people’s records.
+The next step is to create a `user` role for the app. Users should be able to see only their records, but not the other
+people’s records.
 
-Configure the `user` role as shown in the image below. For more information, read about [configuring permission rules in Hasura](https://hasura.io/docs/latest/graphql/core/auth/authorization/permission-rules/).
+Configure the `user` role as shown in the image below. For more information, read about
+[configuring permission rules in Hasura](https://hasura.io/docs/latest/graphql/core/auth/authorization/permission-rules/).
 
 ![Hasura Permissions](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/auth0/hasura-permissions.png)
 
 This way, users cannot read other people’s records. They can only access theirs.
 
-Now go back to Auth0 and go to the `Rules` page. Select the `hasura-auth0-users-sync` or whatever you named the rule. It's the rule you created previously for syncing Auth0 with Hasura.
+Now go back to Auth0 and go to the `Rules` page. Select the `hasura-auth0-users-sync` or whatever you named the rule.
+It's the rule you created previously for syncing Auth0 with Hasura.
 
 Then click on the `Save and try` button, which opens a new pop-up. Add the following data in the `User` tab:
 
@@ -198,7 +217,8 @@ Then click on the `Save and try` button, which opens a new pop-up. Add the follo
 }
 ```
 
-Leave the `Context` tab as it is, and then press the `Try` button. The test should be successful, and you should see the new user in your Hasura app.
+Leave the `Context` tab as it is, and then press the `Try` button. The test should be successful, and you should see the
+new user in your Hasura app.
 
 ![Hasura Users Table](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/auth0/Hasura-users.png)
 
@@ -206,13 +226,16 @@ As the image illustrates, the user was successfully added to the database.
 
 ## Test Auth0 Token
 
-This step involves testing the Auth0 integration. More specifically, you will get a token from Auth0, and you will use it with Hasura to make authenticated requests.
+This step involves testing the Auth0 integration. More specifically, you will get a token from Auth0, and you will use
+it with Hasura to make authenticated requests.
 
-You will get the Auth0 token using the **Authentication API Debugger Extension** from Auth0. Go to the `Extension` page and search for `api debugger`, as shown in the image below.
+You will get the Auth0 token using the **Authentication API Debugger Extension** from Auth0. Go to the `Extension` page
+and search for `api debugger`, as shown in the image below.
 
 ![Auth0 Extensions](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/auth0/auth0-extensions.png)
 
-Follow the instructions to install and authorize the extension. Once you are done with that, you need to configure the Authentication API Debugger.
+Follow the instructions to install and authorize the extension. Once you are done with that, you need to configure the
+Authentication API Debugger.
 
 ![Auth0 Authentication API Debugger](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/auth0/auth0-authentication-api-debugger.png)
 
@@ -220,37 +243,45 @@ Select the application and copy the callback URL.
 
 > You will need the callback URL later.
 
-Now click on the `OAuth2 / OIDC` option to go to the page where you should see a field called `Audience`. Add your Hasura app URL and turn on the "Save in Local Storage" option.
+Now click on the `OAuth2 / OIDC` option to go to the page where you should see a field called `Audience`. Add your
+Hasura app URL and turn on the "Save in Local Storage" option.
 
 See the image for reference.
 
 ![Auth0 Set Audience](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/auth0/auth0-set-audience.png)
 
-After that, go to the application you created in the first step and add the callback URL you copied earlier.  Save the changes, and you are ready to test the application.
+After that, go to the application you created in the first step and add the callback URL you copied earlier. Save the
+changes, and you are ready to test the application.
 
 ![Auth0 Application Settings Callback URLs](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/auth0/auth0-app-settings-callback-urls.png)
 
-Go back to the "Auth0 Authentication API Debugger" again and then to the "OAuth2 / OIDC" page. You should see an option called `OAUTH2/OIDC LOGIN` button under the "User Flows" section.
+Go back to the "Auth0 Authentication API Debugger" again and then to the "OAuth2 / OIDC" page. You should see an option
+called `OAUTH2/OIDC LOGIN` button under the "User Flows" section.
 
 ![Auth0 Test OAUTH2/OIDC LOGIN](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/auth0/auth0-test-login.png)
 
-Click on the button, and within a couple of seconds, you will be redirected to another page. On this page, you can see the following:
-* Hash Fragment
-* Access Token
-* Headers
+Click on the button, and within a couple of seconds, you will be redirected to another page. On this page, you can see
+the following:
+
+- Hash Fragment
+- Access Token
+- Headers
 
 This is where you get the access token that you can use with your Hasura application.
 
 ![Auth0 Access Token](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/auth0/auth0-access-token.png)
 
-The above image illustrates an example access token. You will use that access token with the Authorization header when you make a request to your Hasura app.
+The above image illustrates an example access token. You will use that access token with the Authorization header when
+you make a request to your Hasura app.
 
 You can see a successful request to the Hasura app using the Auth0 Bearer token.
 
 ![Hasura GraphQL Request with Authorization Bearer Token Generated by Auth0](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/auth0/hasura-auth-bearer-token.png)
 
-If you remove the Authorization token, you will get an error telling you that the token is missing. As a result, you cannot access the database records.
+If you remove the Authorization token, you will get an error telling you that the token is missing. As a result, you
+cannot access the database records.
 
 ![Hasura GraphQL Request without Authorization Bearer Token Generated by Auth0](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/auth0/hasura-not-auth-bearer-token.png)
 
-If the Authorization token is present, the users can access their records. If the token is missing, the users cannot access any records. As a result, it can be concluded that the integration works successfully.
+If the Authorization token is present, the users can access their records. If the token is missing, the users cannot
+access any records. As a result, it can be concluded that the integration works successfully.

--- a/tutorials/backend/hasura-authentication/tutorial-site/content/integrations/cognito.md
+++ b/tutorials/backend/hasura-authentication/tutorial-site/content/integrations/cognito.md
@@ -6,60 +6,75 @@ metaDescription: "Learn how to integrate Amazon Cognito with Hasura to secure yo
 
 ## What is Amazon Cognito?
 
-Cognito is Amazon’s product that enables you to implement authentication, authorization, and user management into your applications.
+Cognito is Amazon’s product that enables you to implement authentication, authorization, and user management into your
+applications.
 
 The “User Pool” component of Amazon Cognito allows you to add sign-in and sign-up capabilities to your applications.
 
 ## Set Up User Pools and Hosted Web UI
 
-Navigate to [Cognito](https://console.aws.amazon.com/cognito/home) and click “Create user pool” to start the process of setting up a user pool and enabling the hosted web UI.
+Navigate to [Cognito](https://console.aws.amazon.com/cognito/home) and click “Create user pool” to start the process of
+setting up a user pool and enabling the hosted web UI.
 
-> **Note**: The tutorial uses the new AWS console, which might look different from your console. Switch to the new console before starting the tutorial.
+> **Note**: The tutorial uses the new AWS console, which might look different from your console. Switch to the new
+> console before starting the tutorial.
 
-The first step is to configure the sign-in experience. That means configuring how the users can log into your application.
+The first step is to configure the sign-in experience. That means configuring how the users can log into your
+application.
 
-In this case, the users can only sign in using a username and password. Also, the options under “User name requirements” are turned off. The username should not be case sensitive because `username` would differ from `Username`.
+In this case, the users can only sign in using a username and password. Also, the options under “User name requirements”
+are turned off. The username should not be case sensitive because `username` would differ from `Username`.
 
-Additionally, you can enable “Federated identity providers”, which would allow users to log in with their existing Facebook, Apple, Google, and Amazon accounts. For this tutorial, that is out of the scope.
+Additionally, you can enable “Federated identity providers”, which would allow users to log in with their existing
+Facebook, Apple, Google, and Amazon accounts. For this tutorial, that is out of the scope.
 
 ![AWS Cognito Configure Sign-In Experience](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/configure-signin-experience.png)
 
 Click “Next” to go to the next step. On the second step, you are prompted to:
-* choose a password policy
-* enable/disable/configure multi-factor authentication
-* configure user account recovery options
 
-The tutorial uses the “Cognito defaults” for the password policy and no multi-factor authentication. The default values are enabled for the user account recovery options.
+- choose a password policy
+- enable/disable/configure multi-factor authentication
+- configure user account recovery options
+
+The tutorial uses the “Cognito defaults” for the password policy and no multi-factor authentication. The default values
+are enabled for the user account recovery options.
 
 ![AWS Cognito Configure Security Requirements](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/configure-security-requirements.png)
 
-The next step is to configure the sign-up experience, where you can leave the default values. The default values allow users to register and send verification/confirmation emails.
+The next step is to configure the sign-up experience, where you can leave the default values. The default values allow
+users to register and send verification/confirmation emails.
 
 ![AWS Cognito Configure Sign-Up Experience](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/configure-signup-experience.png)
 
-You configure how the user pool sends email/SMS messages to users on the next page. You can either send messages with Amazon SES or Cognito. Since this is a demo application, choose the option “Send email with Cognito”. You can send up to 50 free emails per day with this option.
+You configure how the user pool sends email/SMS messages to users on the next page. You can either send messages with
+Amazon SES or Cognito. Since this is a demo application, choose the option “Send email with Cognito”. You can send up to
+50 free emails per day with this option.
 
 For production applications, you might want to use Amazon SES.
 
 ![AWS Cognito Configure Message Delivery](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/configure-message-delivery.png)
 
-Navigate to the next step, where you set up the app integration for the newly created user pool. Start by giving it a name and enabling the Cognito Hosted UI option.
+Navigate to the next step, where you set up the app integration for the newly created user pool. Start by giving it a
+name and enabling the Cognito Hosted UI option.
 
 ![AWS Cognito Integrate App](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/integrate-app-part-1.png)
 
-After that, you need to set up a domain to use the Hosted UI. For this tutorial, you can use a Cognito domain which is free.
+After that, you need to set up a domain to use the Hosted UI. For this tutorial, you can use a Cognito domain which is
+free.
 
 ![AWS Cognito Integrate App](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/integrate-app-part-2.png)
 
 Now it’s time to configure the initial app client. Choose the following options:
-* **Public client** for the App type
-* **Don’t generate a client secret** for the Client secret
+
+- **Public client** for the App type
+- **Don’t generate a client secret** for the Client secret
 
 Also, name your client and add the allowed callback URL. Use the figure below as a reference.
 
 ![AWS Cognito Integrate App](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/integrate-app-part-3.png)
 
-Once you configure the client, scroll until you see “Advanced app client settings” and click on it. A new section will appear, where you should see “OAuth 2.0 Grant Types”.
+Once you configure the client, scroll until you see “Advanced app client settings” and click on it. A new section will
+appear, where you should see “OAuth 2.0 Grant Types”.
 
 Enable the “Implicit grant” option so Cognito returns the user pool JWTs to your application.
 
@@ -69,27 +84,34 @@ The app client should also have a sign-out URL. Enter a sign-out URL as shown in
 
 ![AWS Cognito App Client Sign Out URL](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/sign-out-url.png)
 
-That’s all you need to initialize the app client. Click “Next” to go to the last step, which is reviewing the user pool. Review the configuration and create it.
+That’s all you need to initialize the app client. Click “Next” to go to the last step, which is reviewing the user pool.
+Review the configuration and create it.
 
-> The AWS documentation has an extensive section on setting up user pools and enabling a hosted web UI. Follow [these steps](https://docs.aws.amazon.com/cognito/latest/developerguide/getting-started-with-cognito-user-pools.html) for in-depth information about getting started with Cognito User Pools.
+> The AWS documentation has an extensive section on setting up user pools and enabling a hosted web UI. Follow
+> [these steps](https://docs.aws.amazon.com/cognito/latest/developerguide/getting-started-with-cognito-user-pools.html)
+> for in-depth information about getting started with Cognito User Pools.
 
 ## Add Custom Claims to the JWT With a Lambda Function
 
-You need to configure custom JWT claims, which you can do with a Lambda function. Cognito will trigger the Lambda function before generating the token.
+You need to configure custom JWT claims, which you can do with a Lambda function. Cognito will trigger the Lambda
+function before generating the token.
 
-The custom JWT claims tell Hasura about the role of the user making the request. This way, Hasura can enforce the appropriate authorization rules. The rules define what the user making the request is allowed to do.
+The custom JWT claims tell Hasura about the role of the user making the request. This way, Hasura can enforce the
+appropriate authorization rules. The rules define what the user making the request is allowed to do.
 
 Find "AWS Lambda" in your dashboard and create a new function. Choose the following options:
-* **Author from scratch**
-* **Function name** - custom-jwt-claims
-* **Runtime** - Node.js 16.x
-* **Architecture** - x86_64
+
+- **Author from scratch**
+- **Function name** - custom-jwt-claims
+- **Runtime** - Node.js 16.x
+- **Architecture** - x86_64
 
 ![Create new AWS Lambda Function](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/new-lambda-function.png)
 
 After configuring the Lambda function, click “Create function”.
 
-Creating the function takes a few seconds, and then it redirects you to the function dashboard. You should see a section called “Code source” in the dashboard. Replace the content with the following code:
+Creating the function takes a few seconds, and then it redirects you to the function dashboard. You should see a section
+called “Code source” in the dashboard. Replace the content with the following code:
 
 ```
 exports.handler = (event, context, callback) => {
@@ -112,16 +134,19 @@ After adding the new code, click “Deploy” to update the Lambda function.
 
 ## Configure Cognito To Trigger the Lambda Function
 
-Go to the user pool created in the first step (*Amazon Cognito > User pools > your-user-pool*), and find the “User pool properties” tab.
+Go to the user pool created in the first step (_Amazon Cognito > User pools > your-user-pool_), and find the “User pool
+properties” tab.
 
 Now you should see the “Lambda triggers” section. Click “Add Lambda trigger”.
 
 ![User Pool Properties - Lambda Triggers](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/user-pool-lambda-trigger.png)
 
-That takes you to another page, where you can configure the Lambda function to respond to an authentication event. Choose the following options:
-* **Trigger type** - Authentication
-* **Authentication** - Pre token generation trigger
-* **Lambda function** - Choose the lambda function created earlier
+That takes you to another page, where you can configure the Lambda function to respond to an authentication event.
+Choose the following options:
+
+- **Trigger type** - Authentication
+- **Authentication** - Pre token generation trigger
+- **Lambda function** - Choose the lambda function created earlier
 
 ![Configure Lambda Trigger in Amazon Cognito](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/cognito-lambda-trigger.png)
 
@@ -129,19 +154,23 @@ Save the Lambda trigger.
 
 ## Create Hasura App
 
-Navigate to the [Hasura Cloud dashboard](https://cloud.hasura.io/projects) and create a new project.
+Navigate to the [Hasura Cloud dashboard](https://cloud.hasura.io/projects?skip_onboarding=true) and create a new
+project.
 
 Add a database to the project and then create a `users` table with the following columns:
-* `id` of type Text (Primary Key)
-* `username` of type Text
+
+- `id` of type Text (Primary Key)
+- `username` of type Text
 
 See the image below for reference.
 
 ![Picture showing how to create a table in Hasura](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/create-hasura-table.png)
 
-The next step is to create a `user` role for the app. Users should be able to see only their records, but not the other people’s records.
+The next step is to create a `user` role for the app. Users should be able to see only their records, but not the other
+people’s records.
 
-Configure the `user` role as shown in the image below. For more information, read about [configuring permission rules in Hasura](https://hasura.io/docs/latest/graphql/core/auth/authorization/permission-rules/).
+Configure the `user` role as shown in the image below. For more information, read about
+[configuring permission rules in Hasura](https://hasura.io/docs/latest/graphql/core/auth/authorization/permission-rules/).
 
 ![Picture showing how to set permissions in Hasura](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/hasura-set-permissions.png)
 
@@ -149,7 +178,8 @@ This way, users cannot read other people’s records. They can only access their
 
 ## Configure Hasura to Use Cognito Keys
 
-When integrating Cognito with Hasura, you need to add the **JWKS** as a JWT secret. JWKS stands for JSON Web Key Set, and it represents the public keys used to verify the JWT issued by Cognito.
+When integrating Cognito with Hasura, you need to add the **JWKS** as a JWT secret. JWKS stands for JSON Web Key Set,
+and it represents the public keys used to verify the JWT issued by Cognito.
 
 You can construct the JWKS URL as follows:
 
@@ -180,13 +210,16 @@ Click `Add` to add the environment variable to your project.
 
 ## Sync Users Between Hasura and Cognito
 
-There should be a sync between Cognito and Hasura, so the users from Cognito are present in your Hasura database as well. You can keep the two in sync with another Lambda function.
+There should be a sync between Cognito and Hasura, so the users from Cognito are present in your Hasura database as
+well. You can keep the two in sync with another Lambda function.
 
-Create a new Lambda function and name it “sync-users”. After that, export the function to your machine. Click on “Actions” and choose “Export function” from the dropdown menu.
+Create a new Lambda function and name it “sync-users”. After that, export the function to your machine. Click on
+“Actions” and choose “Export function” from the dropdown menu.
 
 ![Export Lambda Function](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/export-function.png)
 
-Create a new folder called “sync-users” and move the function file there. Open the `index.js` file and add the following code:
+Create a new folder called “sync-users” and move the function file there. Open the `index.js` file and add the following
+code:
 
 ```
 const request = require("request");
@@ -196,14 +229,14 @@ exports.handler = (event, context, callback) => {
   const userName = event.userName;
   const hasuraAdminSecret = "<your-admin-secret>";
   const url = "https://<your-hasura-app-url>/v1/graphql";
-  
+
   const upsertUserQuery = `
     mutation($userId: String!, $userName: String!){
       insert_users(objects: [{ id: $userId, username: $userName }], on_conflict: { constraint: users_pkey, update_columns: [] }) {
         affected_rows
       }
     }`
-    
+
   const graphqlReq = { "query": upsertUserQuery, "variables": { "userId": userId, "userName": userName } }
 
   request.post({
@@ -229,7 +262,8 @@ After the commands finish, you should have the following files:
 
 ![sync-users Lambda Function](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/sync-users-folder.png)
 
-Now zip the folder because you will upload it on AWS. Click on “Upload from” and choose “.zip file”. Upload the zip file and then deploy the changes.
+Now zip the folder because you will upload it on AWS. Click on “Upload from” and choose “.zip file”. Upload the zip file
+and then deploy the changes.
 
 ![Upload Code on Lambda](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/upload-zip-lambda.png)
 
@@ -237,14 +271,17 @@ The image below illustrates how the function folder structure should look:
 
 ![sync-users Lambda Function Folder Structure](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/sync-users-lambda-structure.png)
 
-Cognito triggers the Lambda function each time a user logs in or registers to sync the Postgres database with Cognito. If the user is already in the database, the function does not do anything. Otherwise, it adds the user to the Postgres database.
+Cognito triggers the Lambda function each time a user logs in or registers to sync the Postgres database with Cognito.
+If the user is already in the database, the function does not do anything. Otherwise, it adds the user to the Postgres
+database.
 
 The reason for using an `upsert` operation is because the social logins do not distinguish between sign up and log in.
 
 Add the following Lambda trigger:
-* **Trigger type** - Authentication
-* **Authentication** - Post authentication trigger
-* **Lambda function** - Choose the `sync-users` Lambda
+
+- **Trigger type** - Authentication
+- **Authentication** - Post authentication trigger
+- **Lambda function** - Choose the `sync-users` Lambda
 
 ![Add Lambda Trigger in Amazon Cognito](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/post-auth-trigger.png)
 
@@ -252,7 +289,8 @@ Save the trigger after configuring it!
 
 ## Test the Integration
 
-The first step is to create an account. After you create the account, you need to log in. The login triggers the `sync-users` Lambda function, which adds the newly created account to the Postgres database.
+The first step is to create an account. After you create the account, you need to log in. The login triggers the
+`sync-users` Lambda function, which adds the newly created account to the Postgres database.
 
 You can access the hosted Cognito UI as follows:
 
@@ -272,13 +310,16 @@ When you access the hosted UI login page, you should see this page:
 
 ![Cognito Hosted UI Login](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/test-integration-login.png)
 
-Enter the details of the account you created earlier and sign in. Sign-in redirects you to the callback URL you set earlier `https://localhost:3333/cognito-callback`.
+Enter the details of the account you created earlier and sign in. Sign-in redirects you to the callback URL you set
+earlier `https://localhost:3333/cognito-callback`.
 
-You will get an error since no app runs on “localhost:333”. That’s fine because you need the `id_token` from the URL. You should see something similar to the picture below but with different values.
+You will get an error since no app runs on “localhost:333”. That’s fine because you need the `id_token` from the URL.
+You should see something similar to the picture below but with different values.
 
 ![Amazon Cognito Sign In Callback](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/cognito-integration-callback.png)
 
-If you extract the `id_token` and use it to make a request in your Hasura app, you should get only the details of your user.
+If you extract the `id_token` and use it to make a request in your Hasura app, you should get only the details of your
+user.
 
 ![Hasura Cognito Integration](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/cognito/hasura-cognito-integration.png)
 

--- a/tutorials/backend/hasura-authentication/tutorial-site/content/integrations/keycloak.md
+++ b/tutorials/backend/hasura-authentication/tutorial-site/content/integrations/keycloak.md
@@ -11,10 +11,11 @@ Keycloak is an open-source service that enables you to secure your applications 
 It supports standard protocols such as SAML 2.0, OAuth 2.0, and OpenID Connect.
 
 Keycloak comes with features such as:
-* Single-Sign On
-* Social Login
-* Admin Console
-* Account Management Console
+
+- Single-Sign On
+- Social Login
+- Admin Console
+- Account Management Console
 
 In this section, you will learn how to integrate Keycloak with Hasura.
 
@@ -37,7 +38,8 @@ User: admin
 Pass: admin
 ```
 
-After successfully logging in, you will be redirected to the dashboard. The default realm in Keycloak is “Master”, so you will need to create a new one for your Hasura application.
+After successfully logging in, you will be redirected to the dashboard. The default realm in Keycloak is “Master”, so
+you will need to create a new one for your Hasura application.
 
 > You can think of a realm as a workspace that manages users, roles, and groups specific only to that realm.
 
@@ -51,7 +53,8 @@ Choose a name for your new realm and create it.
 
 ![Picture showing how to configure a new realm in Keycloak](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/keycloak-configure-realm.png)
 
-After that, you will be redirected to the newly created realm. From now onwards, all the work will happen in the new realm.
+After that, you will be redirected to the newly created realm. From now onwards, all the work will happen in the new
+realm.
 
 ## Setup Hasura Client in Keycloak
 
@@ -66,18 +69,21 @@ Enter the name of the client and save it.
 ## Keycloak User Roles
 
 In Keycloak, you can create two types of roles:
-* **Realm roles** - all the clients share them
-* **Client roles** - they are available only to that client for which it was created
+
+- **Realm roles** - all the clients share them
+- **Client roles** - they are available only to that client for which it was created
 
 In this case, you will create a “Client role”, so it’s only available to your Hasura application.
 
-Navigate to the “Clients” page and click on your “Hasura” client. After that, go to the “Roles” page, as shown in the image below.
+Navigate to the “Clients” page and click on your “Hasura” client. After that, go to the “Roles” page, as shown in the
+image below.
 
 ![Picture showing the roles page for a specific client in Keycloak](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/keycloak-add-client-role.png)
 
 Click the “Add Role” button.
 
-On the next page, choose `user` as the role name. Regarding the role description, you can leave it empty or add something.
+On the next page, choose `user` as the role name. Regarding the role description, you can leave it empty or add
+something.
 
 ![Picture showing the new role creation page in Keycloak](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/keycloak-add-new-role.png)
 
@@ -87,13 +93,15 @@ Save the role.
 
 Now you have the role, but not a user. That means you need to create a user and assign the role.
 
-Go to the “Users” page and click on “Add user” in the top right corner. That opens a new page where you can add the new user.
+Go to the “Users” page and click on “Add user” in the top right corner. That opens a new page where you can add the new
+user.
 
 ![Pic showing the users page](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/keycloak-create-user.png)
 
 Save the user after adding a username (other details are optional).
 
-Now you need to set up a password for your user, which you can do on the credentials page. You can see the “Credentials” tab at the top of the page.
+Now you need to set up a password for your user, which you can do on the credentials page. You can see the “Credentials”
+tab at the top of the page.
 
 Choose a password for your user and confirm it.
 
@@ -107,7 +115,8 @@ Save it by clicking the “Set Password” button.
 
 Navigate back to the “Users” page and open your user profile page by clicking on the user’s id.
 
-Go to the “Role Mappings” page and select your client in the “Client Roles” field. Then choose the `user` role from the “Available Roles” and add it by clicking “Add Selected”.
+Go to the “Role Mappings” page and select your client in the “Client Roles” field. Then choose the `user` role from the
+“Available Roles” and add it by clicking “Add Selected”.
 
 ![Picture showing the user details page in Keycloak](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/keycloak-add-role-to-user.png)
 
@@ -118,12 +127,14 @@ Your user has the `user` role now.
 Hasura decodes and verifies the JWT token returned by the auth server - Keycloak in this case.
 
 Each token will contain some data about the request, such as:
-* the roles that are allowed to make the request
-* the user id
+
+- the roles that are allowed to make the request
+- the user id
 
 and so on. This way, Hasura can enforce the necessary authorization rules.
 
 These are the `x-hasura-*` values you need to pass in the token:
+
 - `x-hasura-allowed-roles`
 - `x-hasura-default-role`
 - `x-hasura-user-id`
@@ -135,34 +146,37 @@ Keycloak enables you to do that with the “Mappers” feature.
 Navigate to your client and then click on the “Mappers” tab. Once there, click on the “Create” button.
 
 The first Protocol Mapper is for the allowed roles. Add the following values:
-* **Name** - `x-hasura-allowed-roles`
-* **Mapper Type** - User Client Role
-* **Client ID** - your client
-* **Multivalued** - ON
-* **Token Claim Name** - `https://hasura\.io/jwt/claims.x-hasura-allowed-roles`
-* **Claim JSON Type**: String
+
+- **Name** - `x-hasura-allowed-roles`
+- **Mapper Type** - User Client Role
+- **Client ID** - your client
+- **Multivalued** - ON
+- **Token Claim Name** - `https://hasura\.io/jwt/claims.x-hasura-allowed-roles`
+- **Claim JSON Type**: String
 
 Then save it!
 
 ![Picture showing how to set Hasura allowed roles Mapper in Keycloak](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/keycloak-allowed-roles-mapper.png)
 
 The next Protocol Mapper is for the default role. Add the following values:
-* **Name** - `x-hasura-default-role`
-* **Mapper Type** - Hardcoded claim
-* **Claim value** - user
-* **Token Claim Name** - `https://hasura\.io/jwt/claims.x-hasura-default-role`
-* **Claim JSON Type**: String
+
+- **Name** - `x-hasura-default-role`
+- **Mapper Type** - Hardcoded claim
+- **Claim value** - user
+- **Token Claim Name** - `https://hasura\.io/jwt/claims.x-hasura-default-role`
+- **Claim JSON Type**: String
 
 Then save it!
 
 ![Picture showing how to set Hasura default role Mapper in Keycloak](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/keycloak-default-role-mapper.png)
 
 The last Protocol Mapper is for the user id. Add the following values:
-* **Name** - `x-hasura-user-id`
-* **Mapper Type** - User Property
-* **Property** - id
-* **Token Claim Name** - `https://hasura\.io/jwt/claims.x-hasura-user-id`
-* **Claim JSON Type**: String
+
+- **Name** - `x-hasura-user-id`
+- **Mapper Type** - User Property
+- **Property** - id
+- **Token Claim Name** - `https://hasura\.io/jwt/claims.x-hasura-user-id`
+- **Claim JSON Type**: String
 
 Then save it!
 
@@ -172,35 +186,43 @@ Now that you have everything in place, you can start making authenticated reques
 
 ## Build Hasura App
 
-The first step is to go to the [Hasura Cloud dashboard](https://cloud.hasura.io/projects) and create a new project. Create a new project and add a database.
+The first step is to go to the [Hasura Cloud dashboard](https://cloud.hasura.io/projects?skip_onboarding=true) and
+create a new project. Create a new project and add a database.
 
 Now create a `users` table with the following columns:
-* `id` of type Text (Primary Key)
-* `username` of type Text
+
+- `id` of type Text (Primary Key)
+- `username` of type Text
 
 See the image below for reference.
 
 ![Picture showing how to create a table in Hasura](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/hasura-create-table.png)
 
-The next step is to create a `user` role for the app. Users should be able to see only their records, but not the other people’s records.
+The next step is to create a `user` role for the app. Users should be able to see only their records, but not the other
+people’s records.
 
-Configure the `user` role as shown in the image below. For more information, read about [configuring permission rules in Hasura](https://hasura.io/docs/latest/graphql/core/auth/authorization/permission-rules/).
+Configure the `user` role as shown in the image below. For more information, read about
+[configuring permission rules in Hasura](https://hasura.io/docs/latest/graphql/core/auth/authorization/permission-rules/).
 
 ![Picture showing how to set permissions in Hasura](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/hasura-set-permissions.png)
 
 This way, users cannot read other people’s records. They can only access theirs.
 
-For testing purposes, add a dummy user. This is to ensure that when you use the JWT token, you only see your user’s details and not other users’ details.
+For testing purposes, add a dummy user. This is to ensure that when you use the JWT token, you only see your user’s
+details and not other users’ details.
 
 ![Picture showing how to add a table record in Hasura](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/hasura-dummy-user.png)
 
-> **Warning**: The users between Keycloak and Hasura do not synchronize automatically. For this example, you will do it manually. That means copying the details from Keyloack in Hasura. However, you can do that programmatically, but it’s beyond the tutorial’s scope.
+> **Warning**: The users between Keycloak and Hasura do not synchronize automatically. For this example, you will do it
+> manually. That means copying the details from Keyloack in Hasura. However, you can do that programmatically, but it’s
+> beyond the tutorial’s scope.
 
-Remember that you added a user earlier in Keycloak? Navigate back to the “Users” page. In case you do not see any use (like in the image), click on “View all users” and you should see your user.
+Remember that you added a user earlier in Keycloak? Navigate back to the “Users” page. In case you do not see any use
+(like in the image), click on “View all users” and you should see your user.
 
 ![Picture showing the users list in Keycloak](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/keycloak-users-page.png)
 
-Once you see it, click on the “ID” to go to that user’s profile page. 
+Once you see it, click on the “ID” to go to that user’s profile page.
 
 ![Picture showing the user’s profile page in Keycloak](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/keycloak-user-profile-page.png)
 
@@ -218,11 +240,14 @@ Open your Hasura project dashboard and go to the “Env Vars” section. Once th
 
 ![Picture showing Env Vars section in the project dashboard](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/hasura-cloud-project-env-vars.png)
 
-Select `HASURA_GRAPHQL_JWT_SECRET` for the “Key” and then paste the **JWKS Endpoint**. The endpoint should be in the following format:
+Select `HASURA_GRAPHQL_JWT_SECRET` for the “Key” and then paste the **JWKS Endpoint**. The endpoint should be in the
+following format:
 
 ![Picture showing how to add the Hasura GraphQL JWT Secret](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/hasura-add-keycloak-jwt-url.png)
 
-> **Note**: If you run Keycloak locally, it won’t work if you add the localhost URL to Hasura Cloud. You need to upload the `certs.json` file somewhere so Hasura Cloud can access it. If you deployed Keycloak online, you could find your JWKS URI at this URL `<your-url>/realms/<your-realm>/.well-known/openid-configuration`.
+> **Note**: If you run Keycloak locally, it won’t work if you add the localhost URL to Hasura Cloud. You need to upload
+> the `certs.json` file somewhere so Hasura Cloud can access it. If you deployed Keycloak online, you could find your
+> JWKS URI at this URL `<your-url>/realms/<your-realm>/.well-known/openid-configuration`.
 
 Apply the environment variable by pressing the “Add” button.
 
@@ -244,16 +269,19 @@ curl --request POST \
   --data password=test \
   --data grant_type=password \
   --data client_id=hasura
-  ```
+```
 
-Running the above command returns the access token you need. The highlighted part is what you need for your Hasura application.
+Running the above command returns the access token you need. The highlighted part is what you need for your Hasura
+application.
 
 ![Picture showing how to get the access token from Keycloak](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/keycloak-get-token-example.png)
 
-Now you can use the access token to make the authenticated request. Hasura returned the appropriate user rather than returning all the users from the database.
+Now you can use the access token to make the authenticated request. Hasura returned the appropriate user rather than
+returning all the users from the database.
 
 ![Picture showing the access token from Keycloak being used in Hasura](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/keycloak/hasura-keycloak-jwt-example.png)
 
 You are done! You integrated Keycloak with Hasura.
 
-> Here is a useful Github repository on [how to integrate Hasura with Keycloak](https://github.com/janhapke/hasura-keycloak).
+> Here is a useful Github repository on
+> [how to integrate Hasura with Keycloak](https://github.com/janhapke/hasura-keycloak).

--- a/tutorials/backend/hasura-authentication/tutorial-site/content/integrations/supertokens.md
+++ b/tutorials/backend/hasura-authentication/tutorial-site/content/integrations/supertokens.md
@@ -1,47 +1,57 @@
 ---
 title: "SuperTokens"
 metaTitle: "SuperTokens | Hasura Authentication Tutorial"
-metaDescription: "SuperTokens is an Open-Source Auth provider that enables you to implement authentication and session management into your applications. Learn how to integrate SuperTokens with Hasura using JWT"
+metaDescription:
+  "SuperTokens is an Open-Source Auth provider that enables you to implement authentication and session management into
+  your applications. Learn how to integrate SuperTokens with Hasura using JWT"
 ---
 
 ## What is SuperTokens
 
-SuperTokens is an Open-Source Auth provider that enables you to implement authentication and session management into your applications.
+SuperTokens is an Open-Source Auth provider that enables you to implement authentication and session management into
+your applications.
 
 It comes in two flavors:
-* self-hosted - unlimited users and free forever
-* managed version by SuperTokens - free up to 5K monthly active users
+
+- self-hosted - unlimited users and free forever
+- managed version by SuperTokens - free up to 5K monthly active users
 
 **Note**: The tutorial uses the managed version of SuperTokens. Also, the auth API is built using NodeJS.
 
 ## Set up SuperTokens
 
-Using SuperTokens for authentication means that you need to build an auth API that uses the SuperTokens Backend SDK. The app communicates with SuperTokens through the custom auth API.
+Using SuperTokens for authentication means that you need to build an auth API that uses the SuperTokens Backend SDK. The
+app communicates with SuperTokens through the custom auth API.
 
 SuperTokens provides Backend SDKs for:
-* Node.js
-* Go
-* Python
+
+- Node.js
+- Go
+- Python
 
 It also has Frontend SDKs for:
-* Vanilla JS
-* React
-* React-Native
+
+- Vanilla JS
+- React
+- React-Native
 
 ### Create a SuperTokens Managed Service
 
 > If you run a self-hosted (with or without Docker) SuperTokens instance, you can skip this section.
 
-You need to create a SuperTokens account, which gives you a `connectionURI` and an `API key`. When you call the SuperTokens `init` function in your auth API, you will use them.
+You need to create a SuperTokens account, which gives you a `connectionURI` and an `API key`. When you call the
+SuperTokens `init` function in your auth API, you will use them.
 
-Navigate to [supertokens.com](https://supertokens.com/) and click on the "Sign Up" button to start the registration process.
+Navigate to [supertokens.com](https://supertokens.com/) and click on the "Sign Up" button to start the registration
+process.
 
 ![The Homepage of SuperTokens](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/supertokens/supertokens-homepage.png)
 
 You can sign up in three ways:
-* with GitHub
-* with Google
-* manually
+
+- with GitHub
+- with Google
+- manually
 
 Additionally, you can customize the signup form on the left-hand side. You can change colors, fonts, and so on.
 
@@ -61,7 +71,8 @@ That takes you to the "Dashboard" page, where you can see your `connectionURI` a
 
 You will need those later. Also, you will connect your Hasura app to the PostgreSQL database from SuperTokens.
 
-You can retrieve the database connection details by clicking where it says `Access the PostgreSQL database used by this core`. You should see something similar:
+You can retrieve the database connection details by clicking where it says
+`Access the PostgreSQL database used by this core`. You should see something similar:
 
 ![Get PostgreSQL database connection details in SuperTokens](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/supertokens/supertokens-connect-to-database.png)
 
@@ -69,13 +80,15 @@ You will need these details in the next step.
 
 ## Create Hasura App
 
-Navigate to your [Hasura Cloud dashboard](https://cloud.hasura.io/projects) and create a new project.
+Navigate to your [Hasura Cloud dashboard](https://cloud.hasura.io/projects?skip_onboarding=true) and create a new
+project.
 
 Launch the console once the project is created, go to the "DATA" tab, and connect to an existing database.
 
 ![Connect to a database in Hasura](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/supertokens/hasura-connect-database.png)
 
-Under **Connect Database Via**, choose the "Connection Parameters" option to add the connection details manually. Now you need the database details from the previous section.
+Under **Connect Database Via**, choose the "Connection Parameters" option to add the connection details manually. Now
+you need the database details from the previous section.
 
 ![Connect to SuperTokens database from Hasura](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/supertokens/hasura-database-connection-params.png)
 
@@ -89,15 +102,18 @@ Do the same for the "foreign-key relationships".
 
 ![Track relationships in Hasura](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/supertokens/hasura-track-relationships.png)
 
-The next step is to create a `user` role for the app. Users should be able to see only their records, but not the other people’s records.
+The next step is to create a `user` role for the app. Users should be able to see only their records, but not the other
+people’s records.
 
-Configure the `user` role as shown in the image below. For more information, read about [configuring permission rules in Hasura](https://hasura.io/docs/latest/graphql/core/auth/authorization/permission-rules/).
+Configure the `user` role as shown in the image below. For more information, read about
+[configuring permission rules in Hasura](https://hasura.io/docs/latest/graphql/core/auth/authorization/permission-rules/).
 
 ![Hasura Permissions](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/supertokens/hasura-create-user-role.png)
 
 This way, users cannot read other people’s records. They can only access theirs.
 
-> **Note**: The SuperTokens database is only for demo purposes. In a production environment, you should have a separate database.
+> **Note**: The SuperTokens database is only for demo purposes. In a production environment, you should have a separate
+> database.
 
 The next step is implementing the Backend Auth API to interact with SuperTokens.
 
@@ -191,17 +207,20 @@ app.listen(3333, () => console.log("Server started!"));
 ```
 
 For this auth API, you need the:
-* Express Framework
-* SuperTokens Node.js SDK
+
+- Express Framework
+- SuperTokens Node.js SDK
 
 > Even though the implementation is done with Node.js, the concepts also apply to the other Backend SDKs.
 
 It's a basic API that allows people to:
+
 - register
 - login
 - receive a JWT token
 
-When you build with SuperTokens, you need to call the `.init` function and pass some parameters. The parameters allow overriding the default settings.
+When you build with SuperTokens, you need to call the `.init` function and pass some parameters. The parameters allow
+overriding the default settings.
 
 The first parameter is the `supertokens` object.
 
@@ -226,7 +245,8 @@ appInfo: {
   },
 ```
 
-`appInfo` specifies where your API and the frontend client are located. Since there is no frontend implementation, you can use the same URL.
+`appInfo` specifies where your API and the frontend client are located. Since there is no frontend implementation, you
+can use the same URL.
 
 If you had a frontend client, you would replace the `websiteDomain` with the URL of that client.
 
@@ -266,13 +286,15 @@ recipeList: [
 ```
 
 In the above `recipeList`, you:
-* initialize the email/password authentication
-* enable the JWT feature and specify a custom issuer (*you’ll see in the next section how to set the issuer*)
-* add custom claims to the JWT
+
+- initialize the email/password authentication
+- enable the JWT feature and specify a custom issuer (_you’ll see in the next section how to set the issuer_)
+- add custom claims to the JWT
 
 That's all the code you need for a basic auth API that can interact with SuperTokens!
 
-**Note**: If you had a frontend client, you would have to write additional code. You would have to add the following piece of code.
+**Note**: If you had a frontend client, you would have to write additional code. You would have to add the following
+piece of code.
 
 ```
 app.use(cors({
@@ -289,10 +311,12 @@ The value for `origin` would be your frontend client URL.
 Until now, your API is available only locally - on your machine. That means you cannot use it with Hasura Cloud.
 
 There are two ways to make the API accessible to Hasura Cloud:
-* deploy your API
-* make your API publicly with ngrok
 
-This tutorial shows how to make your API available publicly. Check the [ngrok documentation](https://ngrok.com/docs/getting-started) to learn how to get started.
+- deploy your API
+- make your API publicly with ngrok
+
+This tutorial shows how to make your API available publicly. Check the
+[ngrok documentation](https://ngrok.com/docs/getting-started) to learn how to get started.
 
 After setting up "ngrok", go to the "auth-api" folder and run your API locally with the command:
 
@@ -325,11 +349,13 @@ Re-start your server, but leave "ngrok" running. The last step is to add the JWT
 
 ## Integrate SuperTokens with Hasura
 
-The JWKS endpoint is available at `http://localhost:3333/api/jwt/jwks.json`, but Hasura Cloud cannot access the local API.
+The JWKS endpoint is available at `http://localhost:3333/api/jwt/jwks.json`, but Hasura Cloud cannot access the local
+API.
 
 Since you run "ngrok", your JWKS endpoint is available at `<your-ngrok-url>/api/jwt/jwks.json`.
 
-You will set the URL as an environment variable in your Hasura Project. To do so, go to the [Hasura Dashboard](https://cloud.hasura.io/) and then click the "Gear ⚙️" icon.
+You will set the URL as an environment variable in your Hasura Project. To do so, go to the
+[Hasura Dashboard](https://cloud.hasura.io/) and then click the "Gear ⚙️" icon.
 
 After that, go to the `Env vars` section and click the `+ New Env Var` option.
 
@@ -377,7 +403,8 @@ Provided that the request is successful, you should get a similar response:
 {"status":"OK","user":{"email":"supertokens+hasura@email.com","id":"0a9baee6-cd1e-4ccc-92ef-9fa8e2edd75c","timeJoined":1652686138026}}%
 ```
 
-Now you have a user whose email is `supertokens+hasura@email.com`. Since you connected Hasura to the SuperTokens database, the user is available in Hasura too.
+Now you have a user whose email is `supertokens+hasura@email.com`. Since you connected Hasura to the SuperTokens
+database, the user is available in Hasura too.
 
 The next step is to log in. You can do so with the following command:
 
@@ -402,8 +429,9 @@ curl --cookie-jar my_cookies.txt --location --request POST 'https://a182-2a02-2f
 ```
 
 Observe the "cookie" part from the curl command `--cookie-jar my_cookies.txt`. When you sign in, you get two tokens:
-* a refresh token
-* an access token
+
+- a refresh token
+- an access token
 
 The `--cookie-jar my_cookies.txt` part takes the tokens returned by the "signin" endpoint and saves them in a file.
 
@@ -413,7 +441,8 @@ You will need the access token to get the JWT token. Also, you will get a simila
 {"status":"OK","user":{"email":"supertokens+hasura@email.com","id":"0a9baee6-cd1e-4ccc-92ef-9fa8e2edd75c","timeJoined":1652686138026}}%
 ```
 
-When you request the JWT token, you need to pass the tokens. That's what the `--cookie my_cookies.txt` part from the command does.
+When you request the JWT token, you need to pass the tokens. That's what the `--cookie my_cookies.txt` part from the
+command does.
 
 You can retrieve the JWT token as follows:
 
@@ -423,11 +452,13 @@ You can retrieve the JWT token as follows:
 curl --cookie my_cookies.txt --location --request GET 'https://a182-2a02-2f08-e000-fb00-9d0-feeb-e5cd-5e50.eu.ngrok.io/getjwt'
 ```
 
-You can then use the token to make authenticated requests. The image below shows that the database returns only this user's details rather than all users.
+You can then use the token to make authenticated requests. The image below shows that the database returns only this
+user's details rather than all users.
 
 ![SuperTokens with Hasura integration](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura-authentication/supertokens/hasura-bearer-token-example.png)
 
 From here, you can extend the Backend auth API to fit your requirements and build a Frontend client.
 
 Useful links:
-* https://github.com/offscriptio/hasura-supertokens
+
+- https://github.com/offscriptio/hasura-supertokens

--- a/tutorials/backend/hasura/tutorial-site-es/content/setup.md
+++ b/tutorials/backend/hasura/tutorial-site-es/content/setup.md
@@ -1,26 +1,33 @@
 ---
 title: "Despliegue de Hasura"
 metaTitle: "Despliegue de Hasura en Hasura Cloud | Tutorial de GraphQL de Hasura"
-metaDescription: "Este tutorial cubre cómo implementar el motor de GraphQL de Hasura en Hasura Cloud utilizando el despliegue de un solo clic y el acceso a la Consola de Hasura"
+metaDescription:
+  "Este tutorial cubre cómo implementar el motor de GraphQL de Hasura en Hasura Cloud utilizando el despliegue de un
+  solo clic y el acceso a la Consola de Hasura"
 ---
 
 Empecemos por desplegar Hasura.
 
 ## Despliegue de un clic en Hasura Cloud {#one-click-deployment}
 
-La manera más rápida de probar Hasura es a través de Hasura Cloud. ¡[Hasura Cloud](https://hasura.io/cloud/) le ofrece una API de GraphQL escalable, altamente disponible, distribuida mundialmente, totalmente gestionada y segura como servicio!
+La manera más rápida de probar Hasura es a través de Hasura Cloud. ¡[Hasura Cloud](https://hasura.io/cloud/) le ofrece
+una API de GraphQL escalable, altamente disponible, distribuida mundialmente, totalmente gestionada y segura como
+servicio!
 
 Haga clic en el siguiente botón para crear un nuevo proyecto en Hasura Cloud:
 
-<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
 **Nota**: inscribirse es gratis y no se requiere tarjeta de crédito.
 
-Una vez que se registre e inicie sesión, debería ver la siguiente pantalla de bienvenida y se creará automáticamente un nuevo proyecto de Hasura para usted:
+Una vez que se registre e inicie sesión, debería ver la siguiente pantalla de bienvenida y se creará automáticamente un
+nuevo proyecto de Hasura para usted:
 
 ![Página de bienvenida de Hasura Cloud](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-welcome.png)
 
-Una vez que se inicie el proyecto, puede hacer clic en el botón `Launch Console` en la ventana emergente. Si ya tenía una cuenta de Hasura Cloud, puede crear un nuevo proyecto haciendo clic en la acción `+ New Project` en la parte superior y luego en `Launch Console`.
+Una vez que se inicie el proyecto, puede hacer clic en el botón `Launch Console` en la ventana emergente. Si ya tenía
+una cuenta de Hasura Cloud, puede crear un nuevo proyecto haciendo clic en la acción `+ New Project` en la parte
+superior y luego en `Launch Console`.
 
 ## Consola de Hasura {#hasura-console}
 
@@ -28,14 +35,18 @@ Esto abrirá la consola de Hasura para el proyecto. Debería parecerse a esto:
 
 ![Consola de Hasura](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-console.png)
 
-El siguiente paso es conectar la base de datos a Hasura. Podemos hacer uso del nivel de la [base de datos de Postgres](https://hasura.io/learn/database/postgresql/what-is-postgresql/) gratuita de Heroku para configurar esto. Diríjase a la pestaña `Data` en la consola y haga clic en `Connect Database`.
+El siguiente paso es conectar la base de datos a Hasura. Podemos hacer uso del nivel de la
+[base de datos de Postgres](https://hasura.io/learn/database/postgresql/what-is-postgresql/) gratuita de Heroku para
+configurar esto. Diríjase a la pestaña `Data` en la consola y haga clic en `Connect Database`.
 
 Tenemos dos opciones para conectar una base de datos:
 
 - Conecte una base de datos existente
 - Cree la base de datos de Heroku (gratis)
 
-Para iniciar este proceso, vamos a crear una nueva base de datos de Postgres desde cero utilizando Heroku Postgres. Haga clic en la pestaña `Create Heroku Database (Free)`. En esta pestaña, ahora tiene una opción para hacer clic en el botón `Create Database`. Tenga en cuenta que crear una cuenta en Heroku es gratis.
+Para iniciar este proceso, vamos a crear una nueva base de datos de Postgres desde cero utilizando Heroku Postgres. Haga
+clic en la pestaña `Create Heroku Database (Free)`. En esta pestaña, ahora tiene una opción para hacer clic en el botón
+`Create Database`. Tenga en cuenta que crear una cuenta en Heroku es gratis.
 
 ![Cree la base de datos de Heroku](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/create-heroku-database.png)
 
@@ -47,10 +58,12 @@ Después de iniciar sesión en Heroku y hacer clic en `Create Database`, Hasura 
 
 ![Configuración de Heroku de Hasura Cloud](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-heroku-setup.png)
 
-Se necesitarán unos segundos para conectarse a Heroku Postgres e inicializar. Una vez que se establezca la conexión, se le llevará a la página del gestor de datos en la consola, que enumera la base de datos que acabamos de conectar.
+Se necesitarán unos segundos para conectarse a Heroku Postgres e inicializar. Una vez que se establezca la conexión, se
+le llevará a la página del gestor de datos en la consola, que enumera la base de datos que acabamos de conectar.
 
 También puede gestionar el proyecto desde el panel de control de Hasura Cloud.
 
 ![Página del proyecto de Hasura Cloud](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-project-page.png)
 
-¡Genial! ¡Ahora ha desplegado Hasura, conectado una base de datos y tiene la consola de administrador lista para empezar!
+¡Genial! ¡Ahora ha desplegado Hasura, conectado una base de datos y tiene la consola de administrador lista para
+empezar!

--- a/tutorials/backend/hasura/tutorial-site-ja/content/setup.md
+++ b/tutorials/backend/hasura/tutorial-site-ja/content/setup.md
@@ -1,56 +1,66 @@
 ---
 title: "Hasuraをデプロイする"
 metaTitle: "HasuraクラウドにHasuraをデプロイする | Hasura GraphQLチュートリアル"
-metaDescription: "このチュートリアルでは、ワンクリックデプロイを使ってHasuraクラウドにHasura GraphQL Engineをデプロイする方法を学び、Hasuraコンソールにアクセスする方法を学びます。"
+metaDescription:
+  "このチュートリアルでは、ワンクリックデプロイを使ってHasuraクラウドにHasura GraphQL
+  Engineをデプロイする方法を学び、Hasuraコンソールにアクセスする方法を学びます。"
 ---
 
-Hasuraをデプロイしてみましょう。
+Hasura をデプロイしてみましょう。
 
-## Hasuraクラウドでのワンクリックデプロイ {#one-click-deployment}
+## Hasura クラウドでのワンクリックデプロイ {#one-click-deployment}
 
-Hasuraを試す最も早い方法はHasuraクラウドを使うことです。[ Hasuraクラウド ](https://hasura.io/cloud/) は、拡張性、可用性、安全性が高く、グローバルに展開し、完全な管理を実現するGraphQL APIサービスを提供します。
+Hasura を試す最も早い方法は Hasura クラウドを使うことです。[ Hasura クラウド ](https://hasura.io/cloud/) は、拡張性、可
+用性、安全性が高く、グローバルに展開し、完全な管理を実現する GraphQL API サービスを提供します。
 
-以下のボタンをクリックして、Hasuraクラウドで新しいプロジェクトを作成します。
+以下のボタンをクリックして、Hasura クラウドで新しいプロジェクトを作成します。
 
-<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
 **注**：サインアップは無料で、クレジットカードは必要ありません。
 
-登録してサインインすると以下のウェルカム画面が表示されて、新しいHasuraプロジェクトが自動的に作成されます。
+登録してサインインすると以下のウェルカム画面が表示されて、新しい Hasura プロジェクトが自動的に作成されます。
 
 ![ Hasuraクラウドのウェルカムページ ](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-welcome.png)
 
-プロジェクトの初期化が完了したら、ポップアップ画面の `Launch Console` をクリックします。Hasuraクラウドのアカウントを既にお持ちの場合は、画面上部の `+ New Project` アクションをクリックしてから `Launch Console` をクリックします。そうすれば手動で新しいプロジェクトを作成することができます。
+プロジェクトの初期化が完了したら、ポップアップ画面の `Launch Console` をクリックします。Hasura クラウドのアカウントを既
+にお持ちの場合は、画面上部の `+ New Project` アクションをクリックしてから `Launch Console` をクリックします。そうすれば
+手動で新しいプロジェクトを作成することができます。
 
-## Hasuraコンソール {#hasura-console}
+## Hasura コンソール {#hasura-console}
 
-続いてプロジェクトのHasura Consoleを開きます。以下のような画面が表示されます。
+続いてプロジェクトの Hasura Console を開きます。以下のような画面が表示されます。
 
 ![ Hasuraコンソール ](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-console.png)
 
-続いてHasuraをデータベースと接続します。この設定には、Herokuの[Postgresデータベース](https://hasura.io/learn/database/postgresql/what-is-postgresql/) 層（無料）を使用できます。コンソールの `Data` タブに移動して、`Connect Database` をクリックします。
+続いて Hasura をデータベースと接続します。この設定には、Heroku
+の[Postgres データベース](https://hasura.io/learn/database/postgresql/what-is-postgresql/) 層（無料）を使用できます。コ
+ンソールの `Data` タブに移動して、`Connect Database` をクリックします。
 
-データベースに接続するには2つの方法があります。
+データベースに接続するには 2 つの方法があります。
 
 - 既存のデータベースへの接続
-- 新しくHerokuデータベースを作成する（無料）
+- 新しく Heroku データベースを作成する（無料）
 
-ここでは早く先に進めるため、Heroku Postgresを使用して新しいPostgresデータベースを一から作成します。`Create Heroku Database (Free)` タブをクリックしてから、 `Create Database` をクリックします。Herokuアカウントの作成は無料です。
+ここでは早く先に進めるため、Heroku Postgres を使用して新しい Postgres データベースを一から作成します
+。`Create Heroku Database (Free)` タブをクリックしてから、 `Create Database` をクリックします。Heroku アカウントの作成は
+無料です。
 
 ![Heroku データベースの作成](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/create-heroku-database.png)
 
-Heroku にログイン後、`Create Database` をクリックすると、Hasuraクラウドは以下を実行します。
+Heroku にログイン後、`Create Database` をクリックすると、Hasura クラウドは以下を実行します。
 
-- Heroku上にアプリを作成する
-- [Postgresアドオンをインストールする](https://hasura.io/learn/database/postgresql/installation/installing-postgresql/)
-- Hasuraの設定に使用するデータベースのURLを取得する
+- Heroku 上にアプリを作成する
+- [Postgres アドオンをインストールする](https://hasura.io/learn/database/postgresql/installation/installing-postgresql/)
+- Hasura の設定に使用するデータベースの URL を取得する
 
 ![ HasuraクラウドでのHerokuの設定 ](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-heroku-setup.png)
 
-Heroku Postgresへの接続と初期化には数秒かかります。Postgresへの接続が完了するとコンソールのData Managerページが表示され、先ほど接続したデータベースの一覧が表示されます。
+Heroku Postgres への接続と初期化には数秒かかります。Postgres への接続が完了するとコンソールの Data Manager ページが表示
+され、先ほど接続したデータベースの一覧が表示されます。
 
-また、Hasuraクラウドダッシュボードからプロジェクトを管理できます。
+また、Hasura クラウドダッシュボードからプロジェクトを管理できます。
 
 ![Hasuraクラウドプロジェクトページ](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-project-page.png)
 
-完璧です。これでHasuraをデプロイして、データベースに接続して、管理コンソールを使えるようになりました！
+完璧です。これで Hasura をデプロイして、データベースに接続して、管理コンソールを使えるようになりました！

--- a/tutorials/backend/hasura/tutorial-site-zh/content/setup.md
+++ b/tutorials/backend/hasura/tutorial-site-zh/content/setup.md
@@ -8,11 +8,12 @@ metaDescription: "该教程介绍如何使用一键部署功能在 Hasura Cloud 
 
 ## 在 Hasura Cloud 上一键部署 {#one-click-deployment}
 
-测试 Hasura 的最快方式是通过 Hasura Cloud。 [Hasura Cloud](https://hasura.io/cloud/) 提供可扩展、高可用、全球分布、全托管、安全的 GraphQL API 即服务！
+测试 Hasura 的最快方式是通过 Hasura Cloud。 [Hasura Cloud](https://hasura.io/cloud/) 提供可扩展、高可用、全球分布、全托
+管、安全的 GraphQL API 即服务！
 
 单击以下按钮，在 Hasura Cloud 上创建一个新项目：
 
-<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
 **注**： 注册免费，不需要信用卡。
 
@@ -20,7 +21,8 @@ metaDescription: "该教程介绍如何使用一键部署功能在 Hasura Cloud 
 
 ![Hasura Cloud 欢迎页面](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-welcome.png)
 
-在项目初始化后，即可单击弹出屏幕上的`Launch Console`按钮。 如果你之前已有 Hasura Cloud 帐户，则可以单击顶部的`+ New Project`操作，然后单击`Launch Console`，手动创建一个新项目。
+在项目初始化后，即可单击弹出屏幕上的`Launch Console`按钮。 如果你之前已有 Hasura Cloud 帐户，则可以单击顶部
+的`+ New Project`操作，然后单击`Launch Console`，手动创建一个新项目。
 
 ## Hasura 控制台 {#hasura-console}
 
@@ -28,14 +30,17 @@ metaDescription: "该教程介绍如何使用一键部署功能在 Hasura Cloud 
 
 ![Hasura 控制台](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-console.png)
 
-下一步是将数据库连接到 Hasura。 我们可以利用 Heroku 的免费 Postgres 数据库层来设置它。 转到控制台上的`Data`选项卡，然后单击`Connect Database`。
+下一步是将数据库连接到 Hasura。 我们可以利用 Heroku 的免费 Postgres 数据库层来设置它。 转到控制台上的`Data`选项卡，然后
+单击`Connect Database`。
 
 我们提供两个连接数据库的选项：
 
 - 连接现有数据库
 - 创建 Heroku 数据库（免费）
 
-为快速开始这个过程，我们将借助 Heroku Postgres 从零开始创建一个新的 Postgres 数据库。 单击`Create Heroku Database (Free)`选项卡。 在这个选项卡中，你现在可以选择单击`Create Database`按钮。 请注意，在 Heroku 上创建帐户是免费的。
+为快速开始这个过程，我们将借助 Heroku Postgres 从零开始创建一个新的 Postgres 数据库。 单
+击`Create Heroku Database (Free)`选项卡。 在这个选项卡中，你现在可以选择单击`Create Database`按钮。 请注意，在 Heroku 上
+创建帐户是免费的。
 
 ![创建 Heroku 数据库](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/create-heroku-database.png)
 
@@ -47,7 +52,8 @@ metaDescription: "该教程介绍如何使用一键部署功能在 Hasura Cloud 
 
 ![Hasura Cloud Heroku 配置](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-heroku-setup.png)
 
-连接到 Heroku Postgres 并进行初始化需要花费几秒钟的时间。 在建立连接后，你将来到控制台上的“数据管理器”页面，其中列有我们刚刚连接的数据库。
+连接到 Heroku Postgres 并进行初始化需要花费几秒钟的时间。 在建立连接后，你将来到控制台上的“数据管理器”页面，其中列有我们
+刚刚连接的数据库。
 
 你也可以通过 Hasura Cloud 控制面板管理项目。
 

--- a/tutorials/backend/hasura/tutorial-site/content/setup.md
+++ b/tutorials/backend/hasura/tutorial-site/content/setup.md
@@ -1,26 +1,32 @@
 ---
 title: "Deploy Hasura"
 metaTitle: "Deploy Hasura to Hasura Cloud | Hasura GraphQL Tutorial"
-metaDescription: "This tutorial covers how to deploy Hasura GraphQL Engine on Hasura Cloud using one-click deployment and access the Hasura Console"
+metaDescription:
+  "This tutorial covers how to deploy Hasura GraphQL Engine on Hasura Cloud using one-click deployment and access the
+  Hasura Console"
 ---
 
 Let's start by deploying Hasura.
 
 ## One-click deployment on Hasura Cloud {#one-click-deployment}
 
-The fastest way to try out Hasura is via Hasura Cloud. [Hasura Cloud](https://hasura.io/cloud/) gives you a scalable, highly available, globally distributed, fully managed, secure GraphQL API as a service!
+The fastest way to try out Hasura is via Hasura Cloud. [Hasura Cloud](https://hasura.io/cloud/) gives you a scalable,
+highly available, globally distributed, fully managed, secure GraphQL API as a service!
 
 Click on the following button to create a new project on Hasura Cloud:
 
-<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-hasura-backend&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
 **Note**: It is free to signup and no credit card is required.
 
-Once you register and sign in, you should see the following welcome screen and a new Hasura project will be created automatically for you:
+Once you register and sign in, you should see the following welcome screen and a new Hasura project will be created
+automatically for you:
 
 ![Hasura Cloud Welcome Page](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-cloud-welcome.png)
 
-Once the project is initialised, you can click on `Launch Console` button on the pop up screen. If you already have a Hasura Cloud account before, you can manually create a new project by clicking on the `+ New Project` action at the top, followed by `Launch Console`.
+Once the project is initialised, you can click on `Launch Console` button on the pop up screen. If you already have a
+Hasura Cloud account before, you can manually create a new project by clicking on the `+ New Project` action at the top,
+followed by `Launch Console`.
 
 ## Hasura Console {#hasura-console}
 
@@ -28,14 +34,17 @@ This will open up Hasura Console for your project. It should look something like
 
 ![Hasura Console](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/hasura-console-updated.png)
 
-The next step is to connect the database to Hasura. We can make use of Neon's free Postgres database tier to set this up. Head to the `Data` tab on the Console and click on `Connect Database`.
+The next step is to connect the database to Hasura. We can make use of Neon's free Postgres database tier to set this
+up. Head to the `Data` tab on the Console and click on `Connect Database`.
 
 We have two options to connect a database:
 
 - Connect an existing database
 - Create a new database (free)
 
-To quickstart this process, we are going to create a new Postgres DB from scratch using Neon Postgres. Click on `Create New Database (Free)` tab. In this tab, you now have an option to click on the `Connect Neon Database` button. Note that Neon gives you 3 free Posgres database instances.
+To quickstart this process, we are going to create a new Postgres DB from scratch using Neon Postgres. Click on
+`Create New Database (Free)` tab. In this tab, you now have an option to click on the `Connect Neon Database` button.
+Note that Neon gives you 3 free Posgres database instances.
 
 ![Create Neon Database](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/create-neon-database.png)
 
@@ -44,7 +53,8 @@ After logging in to Neon and clicking on `Create Neon Database`, Hasura Cloud wi
 - Create a Postgres database on Neon
 - Fetch database URL that you can use to configure Hasura
 
-It will take a few seconds to connect to Neon Postgres and initialise. Once the connection is established, you will be taken to the Data Manager page on the Console, listing the database that we just connected.
+It will take a few seconds to connect to Neon Postgres and initialise. Once the connection is established, you will be
+taken to the Data Manager page on the Console, listing the database that we just connected.
 
 ![Neon database created](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/neon-database-created.png)
 

--- a/tutorials/database/yugabyte/tutorial-site/content/installation.md
+++ b/tutorials/database/yugabyte/tutorial-site/content/installation.md
@@ -1,7 +1,9 @@
 ---
 title: "Setup and Installation"
 metaTitle: "YugabyteDB Installation and Setup | YugabyteDB Tutorial"
-metaDescription: "In this section, we will learn how to setup YugabyteDB, learn more about connection string and deploy Hasura on Hasura Cloud"
+metaDescription:
+  "In this section, we will learn how to setup YugabyteDB, learn more about connection string and deploy Hasura on
+  Hasura Cloud"
 ---
 
 In this section, we will learn how to setup YugabyteDB and Hasura on Cloud.
@@ -15,17 +17,18 @@ The easiest way to get started with YugabyteDB is by provisioning a free cluster
 
 ![](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/database-yugabyte/create-yugabyte-cluster.gif)
 
-  - Click the "Create a free cluster" button and select the "Yugabyte Cloud Free" instance type.
-  - Name the instance as "demo-cluster" and pick a cloud region that is nearest to you.
-  - Download your credentials for future reference and click Next to create the cluster.
+- Click the "Create a free cluster" button and select the "Yugabyte Cloud Free" instance type.
+- Name the instance as "demo-cluster" and pick a cloud region that is nearest to you.
+- Download your credentials for future reference and click Next to create the cluster.
 
-3. While the cluster is being prepared (may take several minutes), feel free to proceed with the next section of this tutorial by creating a Hasura backed-as-a-service (BaaS).
+3. While the cluster is being prepared (may take several minutes), feel free to proceed with the next section of this
+   tutorial by creating a Hasura backed-as-a-service (BaaS).
 
 ## Deploy Hasura BaaS
 
 Next, provision a free GraphQL BaaS using Hasura Cloud:
 
-1. Create or sign in to your Hasura Cloud account: https://cloud.hasura.io/
+1. Create or sign in to your [Hasura Cloud](https://cloud.hasura.io?skip_onboarding=true) account.
 2. Create a free Hasura project:
 
 ![](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/database-yugabyte/deploy-hasura-baas.gif)
@@ -33,6 +36,7 @@ Next, provision a free GraphQL BaaS using Hasura Cloud:
 3. Click the Create a project button and select the Free Tier option.
 4. Name the project as hasura-yugabyte-demo and click Save.
 
-Your GraphQL BaaS is now ready for usage and can be accessed through the endpoint provided in the GraphQL API section of the project’s settings screen.
+Your GraphQL BaaS is now ready for usage and can be accessed through the endpoint provided in the GraphQL API section of
+the project’s settings screen.
 
 ![](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/database-yugabyte/hasura-cloud-endpoint.png)

--- a/tutorials/mobile/android-apollo/tutorial-site/content/setup.md
+++ b/tutorials/mobile/android-apollo/tutorial-site/content/setup.md
@@ -1,15 +1,17 @@
 ---
 title: "Tutorial & boilerplate setup"
 metaTitle: "Todo app Android boilerplate setup | GraphQL Android Apollo Tutorial"
-metaDescription: "The GraphQL backend is already ready. The task is to convert the static UI into a working realtime app in Android"
+metaDescription:
+  "The GraphQL backend is already ready. The task is to convert the static UI into a working realtime app in Android"
 ---
 
-For this tutorial, the GraphQL backend and the basic app UI is already ready.
-Our task will be to convert the "static" UI into a working realtime app.
+For this tutorial, the GraphQL backend and the basic app UI is already ready. Our task will be to convert the "static"
+UI into a working realtime app.
 
 ### Clone and run the boilerplate
 
-1. Clone the [learn-graphql](https://github.com/hasura/learn-graphql) repo. Execute the following commands in your terminal:
+1. Clone the [learn-graphql](https://github.com/hasura/learn-graphql) repo. Execute the following commands in your
+   terminal:
 
 ```bash
 # make sure git version is >= v2.26
@@ -53,12 +55,14 @@ This is what you should see after the steps above:
 
 We are going to make use of `https://hasura.io/learn/graphql` endpoint for making our GraphQL requests in the tutorial.
 
-Now, if you want to run your own version of the above GraphQL endpoint, you can do so by following the Hasura Backend tutorial
+Now, if you want to run your own version of the above GraphQL endpoint, you can do so by following the Hasura Backend
+tutorial
 
 - Deploy Hasura Cloud
 
-<a href="https://cloud.hasura.io/?pg=learn-react&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-react&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
 - Set up Hasura Backend
 
-Head to [Hasura Backend Tutorial](https://hasura.io/learn/graphql/hasura/setup/#hasuraconsole) and get started with creating your own version.
+Head to [Hasura Backend Tutorial](https://hasura.io/learn/graphql/hasura/setup/#hasuraconsole) and get started with
+creating your own version.

--- a/tutorials/mobile/flutter-graphql/tutorial-site/content/setup.md
+++ b/tutorials/mobile/flutter-graphql/tutorial-site/content/setup.md
@@ -1,15 +1,17 @@
 ---
 title: "Tutorial & boilerplate setup"
 metaTitle: "Todo app Flutter boilerplate setup | GraphQL Flutter Tutorial"
-metaDescription: "The GraphQL backend is already ready. The task is to convert the static UI into a working realtime app in Flutter"
+metaDescription:
+  "The GraphQL backend is already ready. The task is to convert the static UI into a working realtime app in Flutter"
 ---
 
-For this tutorial, the GraphQL backend and the basic app UI is already ready.
-Our task will be to convert the "static" UI into a working realtime app.
+For this tutorial, the GraphQL backend and the basic app UI is already ready. Our task will be to convert the "static"
+UI into a working realtime app.
 
 ### Clone and run the boilerplate
 
-1. Clone the [learn-graphql](https://github.com/hasura/learn-graphql) repo. Execute the following commands in your terminal:
+1. Clone the [learn-graphql](https://github.com/hasura/learn-graphql) repo. Execute the following commands in your
+   terminal:
 
 ```bash
 # make sure git version is >= v2.26
@@ -30,7 +32,8 @@ cd tutorials/mobile/flutter-graphql/app-boilerplate
 ```
 
 3. Run this app in your phone or emulator using `Flutter SDK`
-    - `flutter run`
+
+   - `flutter run`
 
 4. Signup/login as a user to load the todo app screen
 
@@ -51,12 +54,14 @@ This is what you should see after following the steps above:
 
 We are going to make use of `https://hasura.io/learn/graphql` endpoint for making our GraphQL requests in the tutorial.
 
-Now, if you want to run your own version of the above GraphQL endpoint, you can do so by following the Hasura Backend tutorial
+Now, if you want to run your own version of the above GraphQL endpoint, you can do so by following the Hasura Backend
+tutorial
 
 - Deploy Hasura Cloud
 
-<a href="https://cloud.hasura.io/?pg=learn-react&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-react&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
 - Set up Hasura Backend
 
-Head to [Hasura Backend Tutorial](https://hasura.io/learn/graphql/hasura/setup/#hasuraconsole) and get started with creating your own version.
+Head to [Hasura Backend Tutorial](https://hasura.io/learn/graphql/hasura/setup/#hasuraconsole) and get started with
+creating your own version.

--- a/tutorials/mobile/ios-apollo/tutorial-site/content/setup.md
+++ b/tutorials/mobile/ios-apollo/tutorial-site/content/setup.md
@@ -1,15 +1,17 @@
 ---
 title: "Tutorial & boilerplate setup"
 metaTitle: "Todo app iOS boilerplate setup | GraphQL iOS Apollo Tutorial"
-metaDescription: "The GraphQL backend is already ready. The task is to convert the static UI into a working realtime app in iOS"
+metaDescription:
+  "The GraphQL backend is already ready. The task is to convert the static UI into a working realtime app in iOS"
 ---
 
-For this tutorial, the GraphQL backend and the basic app UI is already ready.
-Our task will be to convert the "static" UI into a working realtime app.
+For this tutorial, the GraphQL backend and the basic app UI is already ready. Our task will be to convert the "static"
+UI into a working realtime app.
 
 ### Clone and run the boilerplate
 
-1. Clone the [learn-graphql](https://github.com/hasura/learn-graphql) repo. Execute the following commands in your terminal:
+1. Clone the [learn-graphql](https://github.com/hasura/learn-graphql) repo. Execute the following commands in your
+   terminal:
 
 ```bash
 # make sure git version is >= v2.26
@@ -47,7 +49,7 @@ $ carthage update --platform iOS
 
 This is what you should see after the steps above:
 
-![Boilerplate login](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-ios/boilerplate-login.png )
+![Boilerplate login](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-ios/boilerplate-login.png)
 ![Boilerplate after login](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-ios/boilerplate-todos-landing-selected.png)
 ![Boilerplate feed](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-ios/boilerplate-feed.png)
 ![Boilerplate online](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-ios/boilerplate-online.png)
@@ -65,12 +67,14 @@ This is what you should see after the steps above:
 
 We are going to make use of `https://hasura.io/learn/graphql` endpoint for making our GraphQL requests in the tutorial.
 
-Now, if you want to run your own version of the above GraphQL endpoint, you can do so by following the Hasura Backend tutorial
+Now, if you want to run your own version of the above GraphQL endpoint, you can do so by following the Hasura Backend
+tutorial
 
 - Deploy Hasura Cloud
 
-<a href="https://cloud.hasura.io/?pg=learn-react&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-react&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
 - Set up Hasura Backend
 
-Head to [Hasura Backend Tutorial](https://hasura.io/learn/graphql/hasura/setup/#hasuraconsole) and get started with creating your own version.
+Head to [Hasura Backend Tutorial](https://hasura.io/learn/graphql/hasura/setup/#hasuraconsole) and get started with
+creating your own version.

--- a/tutorials/mobile/react-native-apollo/tutorial-site/content/setup.md
+++ b/tutorials/mobile/react-native-apollo/tutorial-site/content/setup.md
@@ -1,15 +1,18 @@
 ---
 title: "Tutorial & boilerplate setup"
 metaTitle: "Todo app react native boilerplate setup | GraphQL React Native Apollo Tutorial"
-metaDescription: "The GraphQL backend is already ready. The task is to convert the static UI into a working realtime app in React Native"
+metaDescription:
+  "The GraphQL backend is already ready. The task is to convert the static UI into a working realtime app in React
+  Native"
 ---
 
-For this tutorial, the GraphQL backend and the basic app UI is already ready.
-Our task will be to convert the "static" UI into a working realtime app.
+For this tutorial, the GraphQL backend and the basic app UI is already ready. Our task will be to convert the "static"
+UI into a working realtime app.
 
 ### Clone and run the boilerplate
 
-1. Clone the [learn-graphql](https://github.com/hasura/learn-graphql) repo. Execute the following commands in your terminal:
+1. Clone the [learn-graphql](https://github.com/hasura/learn-graphql) repo. Execute the following commands in your
+   terminal:
 
 ```bash
 # make sure git version is >= v2.26
@@ -30,11 +33,13 @@ cd tutorials/mobile/react-native-apollo/app-boilerplate
 ```
 
 3. Make sure you have `expo-cli` installed
-    - `npm install -g expo-cli`
+
+   - `npm install -g expo-cli`
 
 4. Install dependencies and run the app. This will start the development server
-    - `yarn`
-    - `yarn start`
+
+   - `yarn`
+   - `yarn start`
 
 5. Open this app from your phone using `Expo`
 
@@ -57,12 +62,14 @@ This is what you should see after the steps above:
 
 We are going to make use of `https://hasura.io/learn/graphql` endpoint for making our GraphQL requests in the tutorial.
 
-Now, if you want to run your own version of the above GraphQL endpoint, you can do so by following the Hasura Backend tutorial
+Now, if you want to run your own version of the above GraphQL endpoint, you can do so by following the Hasura Backend
+tutorial
 
 - Deploy Hasura Cloud
 
-<a href="https://cloud.hasura.io/?pg=learn-react&plcmt=body&tech=default" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
+<a href="https://cloud.hasura.io/?pg=learn-react&plcmt=body&tech=default&skip_onboarding=true" target="_blank"><img src="https://graphql-engine-cdn.hasura.io/assets/main-site/deploy-hasura-cloud.png" /></a>
 
 - Set up Hasura Backend
 
-Head to [Hasura Backend Tutorial](https://hasura.io/learn/graphql/hasura/setup/#hasuraconsole) and get started with creating your own version.
+Head to [Hasura Backend Tutorial](https://hasura.io/learn/graphql/hasura/setup/#hasuraconsole) and get started with
+creating your own version.


### PR DESCRIPTION
### Description

This PR adds the skip_onboaridng=true query parameter to https://cloud.hasura.io references throughout Learn. This is done with the Growth team to create a smoother experience for users signing up or following guides via Learn (and Docs). The query parameter is [parsed by Lux and saves a key-value pair in local storage](https://github.com/hasura/lux/blob/main/services/cloud/app/src/components/Login/index.tsx#L80C97-L86).

[DOCS-1004](https://hasurahq.atlassian.net/browse/DOCS-1004)

### Related Issues
[`hasura/graphql-engine-mono` #9266](https://github.com/hasura/graphql-engine-mono/pull/9266)

### Solution and Design
I grepped for `cloud.hasura.io` and updated introductory sets of instructions; I also updated the in-page `Deploy to Hasura` button refs.

**It also would appear that Prettier grabbed much of this to wrap text.**
