### PR TITLE
Add message about running mssql on modern macs

### DIFF
--- a/tutorials/database/mssql/tutorial-site/content/installation/3-installing-mssql-mac.md
+++ b/tutorials/database/mssql/tutorial-site/content/installation/3-installing-mssql-mac.md
@@ -31,6 +31,14 @@ sudo docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=<YourStrong@Passw0rd>" \
    -d mcr.microsoft.com/mssql/server:2019-latest
 ```
 
+Note that on modern Macs with Apple Silicon based processors you will likely get a message from Docker along the lines of:
+
+`WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested`
+
+To circumvent this you can navigate to Settings in your Docker Desktop and click Features in Development and check "Use Rosetta for x86/amd64 emulation on Apple Silicon.
+
+Docker will restart and your containers should be running properly. 
+
 3. To view your Docker containers, use the `docker ps` command.
 
 ```bash


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
Adds a note in MSSQL database tutorial for macs about how to use the Docker setting for emulating amd/64 on modern Apple Silicon