### PR TITLE
Updated the word "Posgres" to "Postgres" in the setup page.

### DIFF
--- a/tutorials/backend/hasura/tutorial-site/content/setup.md
+++ b/tutorials/backend/hasura/tutorial-site/content/setup.md
@@ -44,7 +44,7 @@ We have two options to connect a database:
 
 To quickstart this process, we are going to create a new Postgres DB from scratch using Neon Postgres. Click on
 `Create New Database (Free)` tab. In this tab, you now have an option to click on the `Connect Neon Database` button.
-Note that Neon gives you 3 free Posgres database instances.
+Note that Neon gives you 3 free Postgres database instances.
 
 ![Create Neon Database](https://graphql-engine-cdn.hasura.io/learn-hasura/assets/graphql-hasura/create-neon-database.png)
 


### PR DESCRIPTION
This commit fixes a typo on the setup page. The word "Postgres" was misspelled as "Posgres". This change was made to ensure that the setup page is accurate and free of errors.

fix(setup): correct typo in Postgres (close #1003 )

### Description
This commit fixes a typo on the setup page. The word "Posgres" was misspelled as "Postgres" in the database configuration section.

### Related Issues
#1003 : Typo in setup page

### Solution and Design
The typo was fixed by replacing the word "Posgres" with "Postgres" in the database configuration section.

### Steps to test and verify
1. Go to the setup page.
2. Verify that the word "Postgres" is spelled correctly in the database configuration section.

### Limitations, known bugs & workarounds
1. There are no known limitations or bugs in this PR.
2. If you encounter any problems, please open a new issue.
