### PR TITLE
fix(postgresql): correct ALTER TABLE command

### DIFF
--- a/tutorials/database/postgresql/tutorial-site/content/create-alter-drop-ddl/2-postgresql-alter.md
+++ b/tutorials/database/postgresql/tutorial-site/content/create-alter-drop-ddl/2-postgresql-alter.md
@@ -38,7 +38,7 @@ This adds a column called `created_at` with a type timestamptz.
 Lets rename the column from `created_at` to `created`, retaining the same data type. This would look like:
 
 ```sql
-ALTER TABLE users RENAME COLUMN created_at TO created;
+ALTER TABLE users_renamed RENAME COLUMN created_at TO created;
 ```
 
 ## Example of PostgreSQL SET DEFAULT


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Thank you for providing an easily understandable PostgreSQL tutorial :)

While following the tutorial, I found a **minor** mistake in the PostgreSQL Tutorial "ALTER Statements". The instructions involves renaming the "users" table to "users_renamed". Then, the following error occurs:
```sql
postgres=# ALTER TABLE users RENAME COLUMN created_at TO created;
ERROR:  relation "users" does not exist
```

I fixed it like below.
```sql
postgres=# ALTER TABLE users_renamed RENAME COLUMN created_at TO created;
ALTER TABLE
```

Could you review please? Thanks.

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
N/A

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
N/A

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
N/A

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
N/A