### PR TITLE
fix(v3): update secret command used to store connection string (closes #1033)

### DIFF
--- a/tutorials/backend/hasura-v3/tutorial-site/content/metadata/2-add-a-datasource.md
+++ b/tutorials/backend/hasura-v3/tutorial-site/content/metadata/2-add-a-datasource.md
@@ -99,7 +99,7 @@ you to store sensitive information securely. You can quickly create them
 [using the CLI](https://hasura.io/docs/3.0/ci-cd/secrets/) as key-value pairs:
 
 ```bash
-hasura3 secret set --project-id <PROJECT_ID_FROM_PREVIOUS_STEP> <KEY>=<VALUE>
+hasura3 secret set --project <PROJECT_ID_FROM_PREVIOUS_STEP> --environment default --subgraph default --key <KEY> --value <VALUE>
 ```
 
 And then reference the key in your `connection_uris` array:


### PR DESCRIPTION
### Description

Updates the usage of the `secret` command to match with the `v3` cli.

### Related Issues

- Fixes #1033

### Solution

The command should be replaced with:

```bash
hasura3 secret set --project <PROJECT_ID_FROM_PREVIOUS_STEP> --environment default --subgraph default --key <KEY> --value <VALUE>
```
