### PR TITLE
docs: fix login command in prerequisites (close #1050)

### DIFF
--- a/tutorials/backend/hasura-v3-supergraph/tutorial-site/content/setup.md
+++ b/tutorials/backend/hasura-v3-supergraph/tutorial-site/content/setup.md
@@ -26,7 +26,7 @@ You can download the extension from the
 To authenticate your CLI to our network, run the following command:
 
 ```bash
-ddn login
+ddn auth login
 ```
 
 This will open a browser window where you can log in with your Hasura account. Once you've logged in, you can close the

--- a/tutorials/backend/hasura-v3/tutorial-site/content/create.md
+++ b/tutorials/backend/hasura-v3/tutorial-site/content/create.md
@@ -12,7 +12,7 @@ Hasura CLI and then explore it using the Hasura Console.
 If you didn't do so before, to authenticate your CLI, run the following command:
 
 ```bash
-ddn login
+ddn auth login
 ```
 
 This will open up a browser window and initiate an OAuth2 login flow. If the browser window doesn't open automatically,

--- a/tutorials/backend/hasura-v3/tutorial-site/content/setup.md
+++ b/tutorials/backend/hasura-v3/tutorial-site/content/setup.md
@@ -26,7 +26,7 @@ You can download the extension from the
 To authenticate your CLI to our network, run the following command:
 
 ```bash
-ddn login
+ddn auth login
 ```
 
 This will open a browser window where you can log in with your Hasura account. Once you've logged in, you can close the


### PR DESCRIPTION
fix #1050 

### Description
The prerequisites doc had wrong command mentioned. Fixed that to show the correct command.

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#1050 

### Solution and Design
Instead of the command that was there in the doc previously, ```ddn login```, changed that to ```ddn auth login```

### Steps to test and verify
- Test the issue by running ```ddn login``` in CLI
<img width="585" alt="Screenshot 2024-07-26 at 10 51 24 AM" src="https://github.com/user-attachments/assets/5f471928-5cab-426e-8821-a149c028e9b1">
